### PR TITLE
Controller: namespace filter, no historical queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Show how much each namespace cost over the past 5 days with additional CPU and m
 kubectl cost namespace --historical --window 5d --show-cpu --show-memory --show-efficiency
 ```
 
-Show how much each controller cost over the past 5 days with additional PV (persistent volume) cost breakdown.
+Show the projected monthly rate for each controller based on the last 5 days of activity with PV (persistent volume) cost breakdown.
 ``` sh
-kubectl cost controller --historical --window 5d --show-pv
+kubectl cost controller --window 5d --show-pv
 ```
 
 Show the projected monthly rate for each deployment based on the last month of activity with CPU, memory, GPU, PV, and network cost breakdown.

--- a/pkg/cmd/namespace.go
+++ b/pkg/cmd/namespace.go
@@ -72,7 +72,7 @@ func runCostNamespace(ko *KubeOptions, no *CostOptionsNamespace) error {
 		}
 
 		// Use allocations[0] because the query accumulates to a single result
-		err = writeNamespaceTable(ko.Out, allocations[0], no.displayOptions)
+		err = writeAllocationTable(ko.Out, "Namespace", allocations[0], no.displayOptions)
 		if err != nil {
 			return fmt.Errorf("failed to write table output: %s", err)
 		}

--- a/pkg/cmd/output.go
+++ b/pkg/cmd/output.go
@@ -26,7 +26,7 @@ func formatFloat(f float64) string {
 	return fmt.Sprintf("%.6f", f)
 }
 
-func writeNamespaceTable(out io.Writer, allocations map[string]kubecost.Allocation, opts displayOptions) error {
+func writeAllocationTable(out io.Writer, allocationType string, allocations map[string]kubecost.Allocation, opts displayOptions) error {
 	t := table.NewWriter()
 	t.SetOutputMirror(out)
 
@@ -37,7 +37,7 @@ func writeNamespaceTable(out io.Writer, allocations map[string]kubecost.Allocati
 		AutoMerge: true,
 	})
 	columnConfigs = append(columnConfigs, table.ColumnConfig{
-		Name:      "namespace",
+		Name:      allocationType,
 		AutoMerge: true,
 	})
 
@@ -92,7 +92,7 @@ func writeNamespaceTable(out io.Writer, allocations map[string]kubecost.Allocati
 	headerRow := table.Row{}
 
 	headerRow = append(headerRow, "Cluster")
-	headerRow = append(headerRow, "Namespace")
+	headerRow = append(headerRow, allocationType)
 
 	if opts.showCPUCost {
 		headerRow = append(headerRow, CPUCol)
@@ -139,12 +139,12 @@ func writeNamespaceTable(out io.Writer, allocations map[string]kubecost.Allocati
 
 	for _, alloc := range allocations {
 		cluster, _ := alloc.Properties.GetCluster()
-		namespace := alloc.Name
+		allocName := alloc.Name
 
 		allocRow := table.Row{}
 
 		allocRow = append(allocRow, cluster)
-		allocRow = append(allocRow, namespace)
+		allocRow = append(allocRow, allocName)
 
 		if opts.showCPUCost {
 			allocRow = append(allocRow, formatFloat(alloc.CPUCost))


### PR DESCRIPTION
The allocation API suffers the same problems for controllers as it does for deployments, so `kubectl cost` cannot support historical queries for controllers. 

Also adds a namespace filter for controllers just like deployments.