### PR TITLE
--namespace behaves as expected, applying to Kubecost request instead of Kubernetes request

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ kubectl cost deployment --window month -A
 
 Show the projected monthly rate for each deployment in the `kubecost` namespace based on the last 3 days of activity with CPU cost breakdown.
 ``` sh
-kubectl cost deployment --window 3d --show-cpu -N kubecost
+kubectl cost deployment --window 3d --show-cpu -n kubecost
 ```
 
 The same, but with a non-standard Kubecost deployment in the namespace `kubecost-staging` with the cost analyzer service called `kubecost-staging-cost-analyzer`.
 ``` sh
-kubectl cost deployment --window 3d --show-cpu -N kubecost -n kubecost-staging --service-name kubecost-staging-cost-analyzer
+kubectl cost deployment --window 3d --show-cpu -n kubecost -N kubecost-staging --service-name kubecost-staging-cost-analyzer
 ```
 
 
@@ -85,19 +85,20 @@ See `kubectl cost [subcommand] --help` for the full set of flags.
 
 The following flags modify the behavior of the subcommands:
 ```
-    --historical                 show the total cost during the window instead of the projected monthly rate based on the data in the window"
-    --show-cpu                   show data for CPU cost
-    --show-efficiency            show efficiency of cost alongside CPU and memory cost (default true)
-    --show-gpu                   show data for GPU cost
-    --show-memory                show data for memory cost
-    --show-network               show data for network cost
-    --show-pv                    show data for PV (physical volume) cost
-    --show-shared                show shared cost data
--A, --show-all-resources         Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network.
-    --window string              the window of data to query (default "yesterday")
--N, --namespace-filter string    Limit results to only one namespace. Defaults to all namespaces.
-    --service-name string        The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart. (default "kubecost-cost-analyzer")
--n, --namespace string           If present, the namespace scope for this CLI request (i.e. the namespace that Kubecost is running in). (default "kubecost")
+    --historical                  show the total cost during the window instead of the projected monthly rate based on the data in the window"
+    --show-cpu                    show data for CPU cost
+    --show-efficiency             show efficiency of cost alongside CPU and memory cost (default true)
+    --show-gpu                    show data for GPU cost
+    --show-memory                 show data for memory cost
+    --show-network                show data for network cost
+    --show-pv                     show data for PV (physical volume) cost
+    --show-shared                 show shared cost data
+-A, --show-all-resources          Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network.
+    --window string               the window of data to query (default "yesterday")
+-N, --namespace-filter string     Limit results to only one namespace. Defaults to all namespaces.
+    --service-name string         The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart. (default "kubecost-cost-analyzer")
+-n, --namespace string            Limit results to only one namespace. Defaults to all namespaces.
+-N, --kubecost-namespace string   The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace. (default "kubecost")
 ```
 
 
@@ -114,7 +115,6 @@ The following flags modify the behavior of the subcommands:
   -h, --help                           help for cost
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request (i.e. the namespace that Kubecost is running in). (default "kubecost")
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used

--- a/pkg/cmd/controller.go
+++ b/pkg/cmd/controller.go
@@ -44,9 +44,9 @@ func newCmdCostController(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&controllerO.filterNamespace, "namespace-filter", "N", "", "Limit results to only one namespace. Defaults to all namespaces.")
+	cmd.Flags().StringVarP(&controllerO.filterNamespace, "namespace", "n", "", "Limit results to only one namespace. Defaults to all namespaces.")
 	addCostOptionsFlags(cmd, &controllerO.CostOptions)
-	kubeO.configFlags.AddFlags(cmd.Flags())
+	addKubeOptionsFlags(cmd, kubeO)
 
 	return cmd
 }

--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -36,10 +36,10 @@ var (
     %[1]s cost deployment --window month -A
 
     # Show the projected monthly rate for each deployment in the "kubecost" namespace based on the last 3 days of activity with CPU cost breakdown.
-    %[1]s cost deployment --window 3d --show-cpu -N kubecost
+    %[1]s cost deployment --window 3d --show-cpu -n kubecost
 
     # The same, but with a non-standard Kubecost deployment in the namespace "kubecost-staging" with the cost analyzer service called "kubecost-staging-cost-analyzer".
-    %[1]s cost deployment --window 3d --show-cpu -N kubecost -n kubecost-staging --service-name kubecost-staging-cost-analyzer
+    %[1]s cost deployment --window 3d --show-cpu -n kubecost -N kubecost-staging --service-name kubecost-staging-cost-analyzer
 `
 
 	errNoContext = fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
@@ -66,7 +66,9 @@ func NewKubeOptions(streams genericclioptions.IOStreams) *KubeOptions {
 	}
 }
 
-// NewCmdCost provides a cobra command wrapping CostOptions
+// NewCmdCost provides a cobra command that acts as a parent command
+// for all subcommands. It provides only basic usage information. See
+// common.go and the subcommands for the actual functionality.
 func NewCmdCost(
 	streams genericclioptions.IOStreams,
 	GitCommit string,
@@ -75,30 +77,15 @@ func NewCmdCost(
 	GitSummary string,
 	BuildDate string,
 ) *cobra.Command {
-	o := NewKubeOptions(streams)
-
 	cmd := &cobra.Command{
 		Use:          "cost",
 		Short:        "View cluster cost information.",
 		Example:      fmt.Sprintf(costExample, "kubectl"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			// if err := o.Complete(c, args); err != nil {
-			// 	return err
-			// }
-			// if err := o.Validate(); err != nil {
-			// 	return err
-			// }
-			// if err := o.Run(); err != nil {
-			// 	return err
-			// }
 			return fmt.Errorf("please use a subcommand")
-
-			// return nil
 		},
 	}
-
-	o.configFlags.AddFlags(cmd.Flags())
 
 	cmd.AddCommand(newCmdCostNamespace(streams))
 	cmd.AddCommand(newCmdCostDeployment(streams))

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -45,10 +45,10 @@ func newCmdCostDeployment(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&deploymentO.filterNamespace, "namespace-filter", "N", "", "Limit results to only one namespace. Defaults to all namespaces.")
-	addCostOptionsFlags(cmd, &deploymentO.CostOptions)
+	cmd.Flags().StringVarP(&deploymentO.filterNamespace, "namespace", "n", "", "Limit results to only one namespace. Defaults to all namespaces.")
 
-	kubeO.configFlags.AddFlags(cmd.Flags())
+	addCostOptionsFlags(cmd, &deploymentO.CostOptions)
+	addKubeOptionsFlags(cmd, kubeO)
 
 	return cmd
 }

--- a/pkg/cmd/label.go
+++ b/pkg/cmd/label.go
@@ -51,8 +51,9 @@ func newCmdCostLabel(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().StringVarP(&labelO.queryLabel, "label", "l", "", "The label to perform aggregation on, \"app\" is a common one.")
 	cmd.MarkFlagRequired("label")
+
 	addCostOptionsFlags(cmd, &labelO.CostOptions)
-	kubeO.configFlags.AddFlags(cmd.Flags())
+	addKubeOptionsFlags(cmd, kubeO)
 
 	return cmd
 }

--- a/pkg/cmd/namespace.go
+++ b/pkg/cmd/namespace.go
@@ -43,7 +43,7 @@ func newCmdCostNamespace(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	addCostOptionsFlags(cmd, &namespaceO.CostOptions)
-	kubeO.configFlags.AddFlags(cmd.Flags())
+	addKubeOptionsFlags(cmd, kubeO)
 
 	return cmd
 }


### PR DESCRIPTION
This is a breaking API change. The previous behavior of `--namespace`/`-n` was to behave in the same way that it does in `kubectl`, where it scopes the Kubernetes API request. We want it to scope the *Kubecost* API request (when appropriate) instead.

The old behavior of `--namespace`/`-n` is now in
`--kubecost-namespace`/`-N`

Verified by using the new flag behavior (using the examples in the README, including against a staging installation using `-N`) against a GKE cluster.