### PR TITLE
kubectl-cost version not DIRTY from CI build

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -9,7 +9,6 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
 
       - uses: actions/setup-go@v2
         with:
@@ -18,6 +17,8 @@ jobs:
       - name: Install govvv
         run: |
           go get github.com/ahmetb/govvv@master
+
+      - uses: actions/checkout@v2
 
       - name: Make release
         run: |


### PR DESCRIPTION
When kubectl-cost version is run from a release build,
the following is shown:

Git State: dirty

I believe this is because CI installs govvv after
cloning the repo, meaning govvv is added to the
go.mod/go.sum of the repo locally.