### PR TITLE
Also include .tar.gz releases for krew integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,30 @@
 .PHONY: darwin-amd64
 darwin-amd64:
 	cd cmd/kubectl-cost && GOOS=darwin GOARCH=amd64 govvv build -o kubectl-cost-darwin-amd64
+	tar --transform 's|.*kubectl-cost-darwin-amd64|kubectl-cost|' \
+		-czf cmd/kubectl-cost/kubectl-cost-darwin-amd64.tar.gz \
+		cmd/kubectl-cost/kubectl-cost-darwin-amd64
 
 .PHONY: darwin-arm64
 darwin-arm64:
 	cd cmd/kubectl-cost && GOOS=darwin GOARCH=arm64 govvv build -o kubectl-cost-darwin-arm64
+	tar --transform 's|.*kubectl-cost-darwin-arm64|kubectl-cost|' \
+		-czf cmd/kubectl-cost/kubectl-cost-darwin-arm64.tar.gz \
+		cmd/kubectl-cost/kubectl-cost-darwin-arm64
 
 .PHONY: linux-amd64
 linux-amd64:
 	cd cmd/kubectl-cost && GOOS=linux GOARCH=amd64 govvv build -o kubectl-cost-linux-amd64
+	tar --transform 's|.*kubectl-cost-linux-amd64|kubectl-cost|' \
+		-czf cmd/kubectl-cost/kubectl-cost-linux-amd64.tar.gz \
+		cmd/kubectl-cost/kubectl-cost-linux-amd64
 
 .PHONY: windows-amd64
 windows-amd64:
 	cd cmd/kubectl-cost && GOOS=windows GOARCH=amd64 govvv build -o kubectl-cost-windows-amd64
+	tar --transform 's|.*kubectl-cost-windows-amd64|kubectl-cost|' \
+		-czf cmd/kubectl-cost/kubectl-cost-windows-amd64.tar.gz \
+		cmd/kubectl-cost/kubectl-cost-windows-amd64
 
 .PHONY: release
 release: darwin-amd64 darwin-arm64 linux-amd64 windows-amd64


### PR DESCRIPTION
Krew requires that artifact URIs be tars or zips. By
adding the building of .tar.gz of binaries to `make release`,
the CI release process should automatically pick up
the .tar.gzs and publish them as well. Each .tar.gz
contains just one file, called `kubectl-cost`. The platform
information is in the .tar.gz instead.