### PR TITLE
Add LICENSE to release .tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ windows-amd64:
 
 .PHONY: release
 release: darwin-amd64 darwin-arm64 linux-amd64 windows-amd64
+	sha256sum cmd/kubectl-cost/kubectl-cost-darwin-amd64.tar.gz
+	sha256sum cmd/kubectl-cost/kubectl-cost-darwin-arm64.tar.gz
+	sha256sum cmd/kubectl-cost/kubectl-cost-linux-amd64.tar.gz
+	sha256sum cmd/kubectl-cost/kubectl-cost-windows-amd64.tar.gz
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -3,28 +3,32 @@ darwin-amd64:
 	cd cmd/kubectl-cost && GOOS=darwin GOARCH=amd64 govvv build -o kubectl-cost-darwin-amd64
 	tar --transform 's|.*kubectl-cost-darwin-amd64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-darwin-amd64.tar.gz \
-		cmd/kubectl-cost/kubectl-cost-darwin-amd64
+		cmd/kubectl-cost/kubectl-cost-darwin-amd64 \
+		LICENSE
 
 .PHONY: darwin-arm64
 darwin-arm64:
 	cd cmd/kubectl-cost && GOOS=darwin GOARCH=arm64 govvv build -o kubectl-cost-darwin-arm64
 	tar --transform 's|.*kubectl-cost-darwin-arm64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-darwin-arm64.tar.gz \
-		cmd/kubectl-cost/kubectl-cost-darwin-arm64
+		cmd/kubectl-cost/kubectl-cost-darwin-arm64 \
+		LICENSE
 
 .PHONY: linux-amd64
 linux-amd64:
 	cd cmd/kubectl-cost && GOOS=linux GOARCH=amd64 govvv build -o kubectl-cost-linux-amd64
 	tar --transform 's|.*kubectl-cost-linux-amd64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-linux-amd64.tar.gz \
-		cmd/kubectl-cost/kubectl-cost-linux-amd64
+		cmd/kubectl-cost/kubectl-cost-linux-amd64 \
+		LICENSE
 
 .PHONY: windows-amd64
 windows-amd64:
 	cd cmd/kubectl-cost && GOOS=windows GOARCH=amd64 govvv build -o kubectl-cost-windows-amd64
 	tar --transform 's|.*kubectl-cost-windows-amd64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-windows-amd64.tar.gz \
-		cmd/kubectl-cost/kubectl-cost-windows-amd64
+		cmd/kubectl-cost/kubectl-cost-windows-amd64 \
+		LICENSE
 
 .PHONY: release
 release: darwin-amd64 darwin-arm64 linux-amd64 windows-amd64


### PR DESCRIPTION
Required because Krew CI requires a LICENSE in the release archive.