### PR TITLE
Fix TUI not displaying data after options change

### DIFF
--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -35,6 +35,8 @@ func newCmdTUI(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
+	addKubeOptionsFlags(cmd, kubeO)
+
 	return cmd
 }
 


### PR DESCRIPTION
https://github.com/kubecost/kubectl-cost/pull/41 introduced
an error with the TUI because the TUI was not providing
the standard set of options and was instead relying on
this old logic to set a namespace. The TUI now has the correct
flags and defaults for the `KubeOptions`, mitigating the issue.

Tested locally against a cluster running the nightly deployment.