### PR TITLE
Show response data when requests fail

### DIFF
--- a/pkg/query/aggapi.go
+++ b/pkg/query/aggapi.go
@@ -33,7 +33,7 @@ func QueryAggCostModel(clientset *kubernetes.Clientset, kubecostNamespace, servi
 	bytes, err := clientset.CoreV1().Services(kubecostNamespace).ProxyGet("", serviceName, "9090", "/model/aggregatedCostModel", params).DoRaw(ctx)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to proxy get kubecost: %s", err)
+		return nil, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
 	}
 
 	var ar aggCostModelResponse

--- a/pkg/query/allocation.go
+++ b/pkg/query/allocation.go
@@ -89,7 +89,7 @@ func QueryAllocation(clientset *kubernetes.Clientset, kubecostNamespace, service
 	bytes, err := clientset.CoreV1().Services(kubecostNamespace).ProxyGet("", serviceName, "9090", "/model/allocation", params).DoRaw(ctx)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to proxy get kubecost: %s", err)
+		return nil, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
 	}
 
 	var ar allocationResponse


### PR DESCRIPTION
This will provide immense help with debugging. Previously, users
simply received a "request failed" message with no useful information.
Now we will see actual API response data.

Tested locally with a known previous failure case: `kubectl cost namespace` with no data available for `yesterday` without `etl=true` (introduced in https://github.com/kubecost/kubectl-cost/pull/60). In that case, the error message from the API is displayed.