### PR TITLE
QueryCurrencyCode can port forward

### DIFF
--- a/pkg/cmd/controller.go
+++ b/pkg/cmd/controller.go
@@ -53,13 +53,27 @@ func newCmdCostController(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostController(ko *KubeOptions, no *CostOptionsController) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:        ko.restConfig,
+		Ctx:               context.Background(),
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       no.serviceName,
+		UseProxy:          no.useProxy,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", "", no.useProxy, context.Background())
+		aggs, err := query.QueryAggCostModel(query.AggCostModelParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "controller",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
@@ -78,7 +92,15 @@ func runCostController(ko *KubeOptions, no *CostOptionsController) error {
 			currencyCode,
 		)
 	} else {
-		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", no.useProxy, context.Background())
+		allocations, err := query.QueryAllocation(query.AllocationParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "controller",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query allocation API: %s", err)
 		}

--- a/pkg/cmd/controller.go
+++ b/pkg/cmd/controller.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kubecost/cost-model/pkg/kubecost"
 	"github.com/kubecost/kubectl-cost/pkg/query"
 )
 
@@ -54,25 +53,15 @@ func newCmdCostController(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostController(ko *KubeOptions, no *CostOptionsController) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.clientset, *ko.configFlags.Namespace, no.serviceName, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		var aggs map[string]query.Aggregation
-		var err error
-
-		if no.useProxy {
-			aggs, err = query.QueryAggCostModel(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
-		} else {
-			aggs, err = query.QueryAggCostModelFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
+		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", "", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
 
 		// don't show unallocated controller data
@@ -89,18 +78,9 @@ func runCostController(ko *KubeOptions, no *CostOptionsController) error {
 			currencyCode,
 		)
 	} else {
-		var allocations []map[string]kubecost.Allocation
-		var err error
-		if no.useProxy {
-			allocations, err = query.QueryAllocation(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
-		} else {
-			allocations, err = query.QueryAllocationFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
+		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "controller", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query allocation API: %s", err)
 		}
 
 		// Use allocations[0] because the query accumulates to a single result

--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
@@ -79,7 +78,6 @@ type KubeOptions struct {
 	configFlags *genericclioptions.ConfigFlags
 
 	restConfig *rest.Config
-	clientset  *kubernetes.Clientset
 	args       []string
 
 	genericclioptions.IOStreams
@@ -139,11 +137,6 @@ func (o *KubeOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.restConfig, err = o.configFlags.ToRESTConfig()
 	if err != nil {
 		return err
-	}
-
-	o.clientset, err = kubernetes.NewForConfig(o.restConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create clientset: %s", err)
 	}
 
 	return nil

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -56,25 +56,15 @@ func newCmdCostDeployment(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostDeployment(ko *KubeOptions, no *CostOptionsDeployment) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.clientset, *ko.configFlags.Namespace, no.serviceName, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		var aggs map[string]query.Aggregation
-		var err error
-
-		if no.useProxy {
-			aggs, err = query.QueryAggCostModel(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
-		} else {
-			aggs, err = query.QueryAggCostModelFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
+		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", "", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
 
 		// don't show unallocated deployment data
@@ -91,18 +81,9 @@ func runCostDeployment(ko *KubeOptions, no *CostOptionsDeployment) error {
 			currencyCode,
 		)
 	} else {
-		var allocations []map[string]kubecost.Allocation
-		var err error
-		if no.useProxy {
-			allocations, err = query.QueryAllocation(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
-		} else {
-			allocations, err = query.QueryAllocationFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
+		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query allocation API: %s", err)
 		}
 
 		// Use allocations[0] because the query accumulates to a single result

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -56,13 +56,27 @@ func newCmdCostDeployment(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostDeployment(ko *KubeOptions, no *CostOptionsDeployment) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:        ko.restConfig,
+		Ctx:               context.Background(),
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       no.serviceName,
+		UseProxy:          no.useProxy,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", "", no.useProxy, context.Background())
+		aggs, err := query.QueryAggCostModel(query.AggCostModelParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "deployment",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
@@ -81,7 +95,15 @@ func runCostDeployment(ko *KubeOptions, no *CostOptionsDeployment) error {
 			currencyCode,
 		)
 	} else {
-		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "deployment", no.useProxy, context.Background())
+		allocations, err := query.QueryAllocation(query.AllocationParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "deployment",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query allocation API: %s", err)
 		}

--- a/pkg/cmd/label.go
+++ b/pkg/cmd/label.go
@@ -60,13 +60,28 @@ func newCmdCostLabel(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostLabel(ko *KubeOptions, no *CostOptionsLabel) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:        ko.restConfig,
+		Ctx:               context.Background(),
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       no.serviceName,
+		UseProxy:          no.useProxy,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "label", no.queryLabel, no.useProxy, context.Background())
+		aggs, err := query.QueryAggCostModel(query.AggCostModelParameters{
+			RestConfig:          ko.restConfig,
+			Ctx:                 context.Background(),
+			KubecostNamespace:   *ko.configFlags.Namespace,
+			ServiceName:         no.serviceName,
+			Window:              no.window,
+			Aggregate:           "namespace",
+			AggregationSubfield: no.queryLabel,
+			UseProxy:            no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
@@ -83,7 +98,15 @@ func runCostLabel(ko *KubeOptions, no *CostOptionsLabel) error {
 			currencyCode,
 		)
 	} else {
-		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, fmt.Sprintf("label:%s", no.queryLabel), no.useProxy, context.Background())
+		allocations, err := query.QueryAllocation(query.AllocationParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         fmt.Sprintf("label:%s", no.queryLabel),
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query allocation API: %s", err)
 		}

--- a/pkg/cmd/namespace.go
+++ b/pkg/cmd/namespace.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kubecost/cost-model/pkg/kubecost"
 	"github.com/kubecost/kubectl-cost/pkg/query"
 )
 
@@ -51,25 +50,15 @@ func newCmdCostNamespace(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostNamespace(ko *KubeOptions, no *CostOptionsNamespace) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.clientset, *ko.configFlags.Namespace, no.serviceName, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		var aggs map[string]query.Aggregation
-		var err error
-
-		if no.useProxy {
-			aggs, err = query.QueryAggCostModel(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
-		} else {
-			aggs, err = query.QueryAggCostModelFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
+		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", "", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
 
 		writeAggregationRateTable(
@@ -81,18 +70,9 @@ func runCostNamespace(ko *KubeOptions, no *CostOptionsNamespace) error {
 			currencyCode,
 		)
 	} else {
-		var allocations []map[string]kubecost.Allocation
-		var err error
-		if no.useProxy {
-			allocations, err = query.QueryAllocation(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
-		} else {
-			allocations, err = query.QueryAllocationFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
+		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query allocation API: %s", err)
 		}
 
 		// Use allocations[0] because the query accumulates to a single result

--- a/pkg/cmd/namespace.go
+++ b/pkg/cmd/namespace.go
@@ -50,13 +50,27 @@ func newCmdCostNamespace(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostNamespace(ko *KubeOptions, no *CostOptionsNamespace) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:        ko.restConfig,
+		Ctx:               context.Background(),
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       no.serviceName,
+		UseProxy:          no.useProxy,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", "", no.useProxy, context.Background())
+		aggs, err := query.QueryAggCostModel(query.AggCostModelParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "namespace",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
@@ -70,7 +84,15 @@ func runCostNamespace(ko *KubeOptions, no *CostOptionsNamespace) error {
 			currencyCode,
 		)
 	} else {
-		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "namespace", no.useProxy, context.Background())
+		allocations, err := query.QueryAllocation(query.AllocationParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "namespace",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query allocation API: %s", err)
 		}

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -53,13 +53,27 @@ func newCmdCostPod(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostPod(ko *KubeOptions, no *CostOptionsPod) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:        ko.restConfig,
+		Ctx:               context.Background(),
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       no.serviceName,
+		UseProxy:          no.useProxy,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", "", no.useProxy, context.Background())
+		aggs, err := query.QueryAggCostModel(query.AggCostModelParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "pod",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
@@ -78,7 +92,15 @@ func runCostPod(ko *KubeOptions, no *CostOptionsPod) error {
 			currencyCode,
 		)
 	} else {
-		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", no.useProxy, context.Background())
+		allocations, err := query.QueryAllocation(query.AllocationParameters{
+			RestConfig:        ko.restConfig,
+			Ctx:               context.Background(),
+			KubecostNamespace: *ko.configFlags.Namespace,
+			ServiceName:       no.serviceName,
+			Window:            no.window,
+			Aggregate:         "pod",
+			UseProxy:          no.useProxy,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query allocation API: %s", err)
 		}

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kubecost/cost-model/pkg/kubecost"
 	"github.com/kubecost/kubectl-cost/pkg/query"
 )
 
@@ -54,25 +53,15 @@ func newCmdCostPod(streams genericclioptions.IOStreams) *cobra.Command {
 
 func runCostPod(ko *KubeOptions, no *CostOptionsPod) error {
 
-	currencyCode, err := query.QueryCurrencyCode(ko.clientset, *ko.configFlags.Namespace, no.serviceName, context.Background())
+	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.useProxy, context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	if !no.isHistorical {
-		var aggs map[string]query.Aggregation
-		var err error
-
-		if no.useProxy {
-			aggs, err = query.QueryAggCostModel(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
-		} else {
-			aggs, err = query.QueryAggCostModelFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", "", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query agg cost model: %s", err)
-			}
+		aggs, err := query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", "", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query agg cost model: %s", err)
 		}
 
 		// don't show unallocated controller data
@@ -89,18 +78,9 @@ func runCostPod(ko *KubeOptions, no *CostOptionsPod) error {
 			currencyCode,
 		)
 	} else {
-		var allocations []map[string]kubecost.Allocation
-		var err error
-		if no.useProxy {
-			allocations, err = query.QueryAllocation(ko.clientset, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
-		} else {
-			allocations, err = query.QueryAllocationFwd(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", context.Background())
-			if err != nil {
-				return fmt.Errorf("failed to query allocation API: %s", err)
-			}
+		allocations, err := query.QueryAllocation(ko.restConfig, *ko.configFlags.Namespace, no.serviceName, no.window, "pod", no.useProxy, context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to query allocation API: %s", err)
 		}
 
 		// Use allocations[0] because the query accumulates to a single result

--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -168,7 +168,7 @@ func runTUI(ko *KubeOptions, do displayOptions) error {
 	queryContext, queryCancel := context.WithCancel(context.Background())
 
 	// TODO: use flags for service name
-	currencyCode, err := query.QueryCurrencyCode(ko.clientset, *ko.configFlags.Namespace, "kubecost-cost-analyzer", queryContext)
+	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, "kubecost-cost-analyzer", true, queryContext)
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
@@ -214,7 +214,7 @@ func runTUI(ko *KubeOptions, do displayOptions) error {
 			queryContext, queryCancel = context.WithCancel(context.Background())
 
 			// TODO: use flags for service name
-			aggs, err = query.QueryAggCostModel(ko.clientset, *ko.configFlags.Namespace, "kubecost-cost-analyzer", windowOptions[windowIndex], aggregation, "", queryContext)
+			aggs, err = query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, "kubecost-cost-analyzer", windowOptions[windowIndex], aggregation, "", true, queryContext)
 
 			if err != nil && strings.Contains(err.Error(), "context canceled") {
 				// do nothing, because the context got canceled to favor a more

--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -168,7 +168,13 @@ func runTUI(ko *KubeOptions, do displayOptions) error {
 	queryContext, queryCancel := context.WithCancel(context.Background())
 
 	// TODO: use flags for service name
-	currencyCode, err := query.QueryCurrencyCode(ko.restConfig, *ko.configFlags.Namespace, "kubecost-cost-analyzer", true, queryContext)
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:        ko.restConfig,
+		Ctx:               queryContext,
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       "kubecost-cost-analyzer",
+		UseProxy:          true,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
@@ -214,7 +220,15 @@ func runTUI(ko *KubeOptions, do displayOptions) error {
 			queryContext, queryCancel = context.WithCancel(context.Background())
 
 			// TODO: use flags for service name
-			aggs, err = query.QueryAggCostModel(ko.restConfig, *ko.configFlags.Namespace, "kubecost-cost-analyzer", windowOptions[windowIndex], aggregation, "", true, queryContext)
+			aggs, err = query.QueryAggCostModel(query.AggCostModelParameters{
+				RestConfig:        ko.restConfig,
+				Ctx:               queryContext,
+				KubecostNamespace: *ko.configFlags.Namespace,
+				ServiceName:       "kubecost-cost-analyzer",
+				Window:            windowOptions[windowIndex],
+				Aggregate:         aggregation,
+				UseProxy:          true,
+			})
 
 			if err != nil && strings.Contains(err.Error(), "context canceled") {
 				// do nothing, because the context got canceled to favor a more

--- a/pkg/query/allocation.go
+++ b/pkg/query/allocation.go
@@ -73,37 +73,48 @@ type allocationResponse struct {
 	Data []map[string]kubecost.Allocation `json:"data"`
 }
 
+type AllocationParameters struct {
+	RestConfig *rest.Config
+	Ctx        context.Context
+
+	KubecostNamespace string
+	ServiceName       string
+	Window            string
+	Aggregate         string
+	UseProxy          bool
+}
+
 // QueryAllocation queries /model/allocation by proxying a request to Kubecost
 // through the Kubernetes API server if useProxy is true or, if it isn't, by
 // temporarily port forwarding to a Kubecost pod.
-func QueryAllocation(restConfig *rest.Config, kubecostNamespace, serviceName, window, aggregate string, useProxy bool, ctx context.Context) ([]map[string]kubecost.Allocation, error) {
+func QueryAllocation(p AllocationParameters) ([]map[string]kubecost.Allocation, error) {
 
-	params := map[string]string{
+	requestParams := map[string]string{
 		// if we set this to false, output would be
 		// per-day (we could use it in a more
 		// complicated way to build in-terminal charts)
 		"accumulate": "true",
-		"window":     window,
+		"window":     p.Window,
 	}
 
-	if aggregate != "" {
-		params["aggregate"] = aggregate
+	if p.Aggregate != "" {
+		requestParams["aggregate"] = p.Aggregate
 	}
 
 	var bytes []byte
 	var err error
-	if useProxy {
-		clientset, err := kubernetes.NewForConfig(restConfig)
+	if p.UseProxy {
+		clientset, err := kubernetes.NewForConfig(p.RestConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create clientset: %s", err)
 		}
 
-		bytes, err = clientset.CoreV1().Services(kubecostNamespace).ProxyGet("", serviceName, "9090", "/model/allocation", params).DoRaw(ctx)
+		bytes, err = clientset.CoreV1().Services(p.KubecostNamespace).ProxyGet("", p.ServiceName, "9090", "/model/allocation", requestParams).DoRaw(p.Ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
 		}
 	} else {
-		bytes, err = portForwardedQueryService(restConfig, kubecostNamespace, serviceName, "model/allocation", params, ctx)
+		bytes, err = portForwardedQueryService(p.RestConfig, p.KubecostNamespace, p.ServiceName, "model/allocation", requestParams, p.Ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to port forward query: %s", err)
 		}


### PR DESCRIPTION
Necessary because #80 didn't fix the permission problem -- the currency code request was still going through the API server proxy method.

Also includes refactors to stop duplicating query code.

Tested locally against a GKE cluster.