### PR TITLE
Change default window to 1d

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The following flags modify the behavior of the subcommands:
     --show-pv                     show data for PV (physical volume) cost
     --show-shared                 show shared cost data
 -A, --show-all-resources          Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency.
-    --window string               The window of data to query. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here. (default "yesterday")
+    --window string               The window of data to query. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here. (default "1d")
     --service-name string         The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart. (default "kubecost-cost-analyzer")
 -n, --namespace string            Limit results to only one namespace. Defaults to all namespaces.
 -N, --kubecost-namespace string   The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace. (default "kubecost")

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -41,7 +41,7 @@ type displayOptions struct {
 }
 
 func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
-	cmd.Flags().StringVar(&options.window, "window", "yesterday", "The window of data to query. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
+	cmd.Flags().StringVar(&options.window, "window", "1d", "The window of data to query. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 	cmd.Flags().BoolVar(&options.isHistorical, "historical", false, "show the total cost during the window instead of the projected monthly rate based on the data in the window")
 	cmd.Flags().BoolVar(&options.showCPUCost, "show-cpu", false, "show data for CPU cost")
 	cmd.Flags().BoolVar(&options.showMemoryCost, "show-memory", false, "show data for memory cost")


### PR DESCRIPTION
While "yesterday" is technically the most correct way to query
exactly 1 day of data right now, it shows unexpected empty
responses for users who have just installed Kubecost and have
no data for yesterday. This introduces a better default experience
for new users.

I chose `1d` instead of `today` because `today` can seriously underreport if the time is just after UTC midnight. `1d` will likely slightly overreport but that overreporting is temporary and will be automatically resolved by the release and deployment of hourly ETL.