### PR TITLE
Add "show-lb" flag for displaying Load Balancer Cost in "--historical" queries.

### DIFF
--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -50,7 +50,7 @@ func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
 	cmd.Flags().BoolVar(&options.showPVCost, "show-pv", false, "show data for PV (physical volume) cost")
 	cmd.Flags().BoolVar(&options.showNetworkCost, "show-network", false, "show data for network cost")
 	cmd.Flags().BoolVar(&options.showSharedCost, "show-shared", false, "show shared cost data")
-	cmd.Flags().BoolVar(&options.showLoadBalancerCost, "show-loadbalancer", false, "show load balancer cost data")
+	cmd.Flags().BoolVar(&options.showLoadBalancerCost, "show-lb", false, "show load balancer cost data")
 	cmd.Flags().BoolVar(&options.showEfficiency, "show-efficiency", true, "show efficiency of cost alongside CPU and memory cost")
 	cmd.Flags().BoolVarP(&options.showAll, "show-all-resources", "A", false, "Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency.")
 	cmd.Flags().StringVar(&options.serviceName, "service-name", "kubecost-cost-analyzer", "The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart.")

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -31,13 +31,14 @@ type CostOptions struct {
 }
 
 type displayOptions struct {
-	showCPUCost     bool
-	showMemoryCost  bool
-	showGPUCost     bool
-	showPVCost      bool
-	showNetworkCost bool
-	showEfficiency  bool
-	showSharedCost  bool
+	showCPUCost          bool
+	showMemoryCost       bool
+	showGPUCost          bool
+	showPVCost           bool
+	showNetworkCost      bool
+	showEfficiency       bool
+	showSharedCost       bool
+	showLoadBalancerCost bool
 }
 
 func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
@@ -49,6 +50,7 @@ func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
 	cmd.Flags().BoolVar(&options.showPVCost, "show-pv", false, "show data for PV (physical volume) cost")
 	cmd.Flags().BoolVar(&options.showNetworkCost, "show-network", false, "show data for network cost")
 	cmd.Flags().BoolVar(&options.showSharedCost, "show-shared", false, "show shared cost data")
+	cmd.Flags().BoolVar(&options.showLoadBalancerCost, "show-loadbalancer", false, "show load balancer cost data")
 	cmd.Flags().BoolVar(&options.showEfficiency, "show-efficiency", true, "show efficiency of cost alongside CPU and memory cost")
 	cmd.Flags().BoolVarP(&options.showAll, "show-all-resources", "A", false, "Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency.")
 	cmd.Flags().StringVar(&options.serviceName, "service-name", "kubecost-cost-analyzer", "The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart.")
@@ -85,6 +87,7 @@ func (co *CostOptions) Complete() {
 		co.showPVCost = true
 		co.showNetworkCost = true
 		co.showSharedCost = true
+		co.showLoadBalancerCost = true
 	}
 }
 

--- a/pkg/cmd/output.go
+++ b/pkg/cmd/output.go
@@ -23,6 +23,7 @@ const (
 	PVCol               = "PV"
 	NetworkCol          = "Network"
 	SharedCol           = "Shared Cost"
+	LoadBalancerCol     = "Load Balancer Cost"
 )
 
 func formatFloat(f float64) string {
@@ -102,6 +103,12 @@ func makeAllocationTable(allocationType string, allocations map[string]kubecost.
 		})
 	}
 
+	if opts.showLoadBalancerCost {
+		columnConfigs = append(columnConfigs, table.ColumnConfig{
+			Name: LoadBalancerCol,
+		})
+	}
+
 	columnConfigs = append(columnConfigs, table.ColumnConfig{
 		Name:        "Total Cost (All)",
 		Align:       text.AlignRight,
@@ -156,6 +163,10 @@ func makeAllocationTable(allocationType string, allocations map[string]kubecost.
 		headerRow = append(headerRow, SharedCol)
 	}
 
+	if opts.showLoadBalancerCost {
+		headerRow = append(headerRow, LoadBalancerCol)
+	}
+
 	headerRow = append(headerRow, "Total Cost (All)")
 
 	if opts.showEfficiency {
@@ -177,6 +188,7 @@ func makeAllocationTable(allocationType string, allocations map[string]kubecost.
 	var summedPV float64
 	var summedNetwork float64
 	var summedShared float64
+	var summedLoadBalancer float64
 
 	for _, alloc := range allocations {
 		cluster := alloc.Properties.Cluster
@@ -227,6 +239,11 @@ func makeAllocationTable(allocationType string, allocations map[string]kubecost.
 			summedShared += alloc.SharedCost
 		}
 
+		if opts.showLoadBalancerCost {
+			allocRow = append(allocRow, formatFloat(alloc.LoadBalancerCost))
+			summedLoadBalancer += alloc.LoadBalancerCost
+		}
+
 		cumulativeCost := formatFloat(alloc.TotalCost())
 		allocRow = append(allocRow, cumulativeCost)
 
@@ -274,6 +291,10 @@ func makeAllocationTable(allocationType string, allocations map[string]kubecost.
 
 	if opts.showSharedCost {
 		footerRow = append(footerRow, formatFloat(summedShared))
+	}
+
+	if opts.showLoadBalancerCost {
+		footerRow = append(footerRow, formatFloat(summedLoadBalancer))
 	}
 
 	footerRow = append(footerRow, fmt.Sprintf("%s %s", currencyCode, formatFloat(summedCost)))


### PR DESCRIPTION
As described in https://github.com/kubecost/kubectl-cost/issues/85.

Tested this locally with https://github.com/kubecost/docs/blob/master/kubecost-lb.yaml, which seems to work.

