### PR TITLE
Add node subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ kubectl cost pod \
   -n kube-system
 ```
 
+Alternatively, kubectl cost can show cost by the asset type.
+To view node cost with breakdowns of RAM and CPU cost for a 
+window of 7 days.
+``` sh
+kubectl cost node \
+  --historical \
+  --window 7d \
+  --show-cpu \
+  --show-memory
+```
+
+Which yields an output with this format:
+```
++-------------+---------------------------------------------+---------------+--------------+---------------+
+| CLUSTER     | NAME                                        | CPU COST      | RAM COST     | TOTAL COST    |
++-------------+---------------------------------------------+---------------+--------------+---------------+
+| cluster-one | gke-test-cluster-default-pool-d6266c7c-dqms |      4.128570 |     2.128920 |      6.257491 |
+|             | gke-test-cluster-pool-1-9bb98ef8-3w6g       |      4.128570 |     2.128920 |      6.257491 |
+|             | gke-test-cluster-pool-1-9bb98ef8-cf3j       |      4.128570 |     2.128924 |      6.257495 |
+|             | gke-test-cluster-pool-1-9bb98ef8-kdsf       |      4.128570 |     2.128924 |      6.257495 |
++-------------+---------------------------------------------+---------------+--------------+---------------+
+| SUMMED      |                                             | USD 16.514280 | USD 8.515688 | USD 25.029972 |
++-------------+---------------------------------------------+---------------+--------------+---------------+
+```
 
 #### Flags
 See `kubectl cost [subcommand] --help` for the full set of flags.
@@ -148,14 +172,16 @@ See `kubectl cost [subcommand] --help` for the full set of flags.
 The following flags modify the behavior of the subcommands:
 ```
     --historical                  show the total cost during the window instead of the projected monthly rate based on the data in the window"
+    --show-asset-type             show type of assets displayed.
     --show-cpu                    show data for CPU cost
     --show-efficiency             show efficiency of cost alongside cost where available (default true)
     --show-gpu                    show data for GPU cost
+    --show-lb                     show load balancer cost data
     --show-memory                 show data for memory cost
     --show-network                show data for network cost
     --show-pv                     show data for PV (physical volume) cost
     --show-shared                 show shared cost data
--A, --show-all-resources          Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency.
+-A, --show-all-resources          Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency for namespace, deployment, controller, lable and pod OR --show-type --show-cpu --show-memory for node.
     --window string               The window of data to query. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here. (default "1d")
     --service-name string         The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart. (default "kubecost-cost-analyzer")
 -n, --namespace string            Limit results to only one namespace. Defaults to all namespaces.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 ## Usage
 
-There are several supported subcommands: `namespace`, `deployment`, `controller`, `label`, `pod`, and `tui`, which display cost information aggregated by the name of the subcommand (see Examples). Each subcommand has two primary modes, rate and non-rate. Rate (the default) displays the projected monthly cost based on the activity during the window. Non-rate (`--historical`) displays the total cost for the duration of the window.
+There are several supported subcommands: `namespace`, `deployment`, `controller`, `label`, `pod`, `node`, and `tui`, which display cost information aggregated by the name of the subcommand (see Examples). Each subcommand has two primary modes, rate and non-rate. Rate (the default) displays the projected monthly cost based on the activity during the window. Non-rate (`--historical`) displays the total cost for the duration of the window.
 
 The exception to these descriptions is `kubectl cost tui`, which displays a TUI and is currently limited to only monthly rate projections. It currently supports all of the previously mentioned aggregations except label. These limitations are because the TUI is an experimental feature - if you like it, let us know! We'd be happy to dedicate time to expanding its functionality.
 

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -43,7 +43,6 @@ type displayOptions struct {
 	showSharedCost       bool
 	showLoadBalancerCost bool
 	showAssetType        bool
-	showRAMCost          bool
 }
 
 func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
@@ -57,9 +56,8 @@ func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
 	cmd.Flags().BoolVar(&options.showSharedCost, "show-shared", false, "show shared cost data")
 	cmd.Flags().BoolVar(&options.showLoadBalancerCost, "show-lb", false, "show load balancer cost data")
 	cmd.Flags().BoolVar(&options.showEfficiency, "show-efficiency", true, "show efficiency of cost alongside CPU and memory cost")
-	cmd.Flags().BoolVar(&options.showAssetType, "show-type", false, "show type of assets displayed.")
-	cmd.Flags().BoolVar(&options.showRAMCost, "show-ram", false, "show data for RAM cost")
-	cmd.Flags().BoolVarP(&options.showAll, "show-all-resources", "A", false, "Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency for namespace, deployment, controller, lable and pod OR --show-type --show-cpu --show-ram for node.")
+	cmd.Flags().BoolVar(&options.showAssetType, "show-asset-type", false, "show type of assets displayed.")
+	cmd.Flags().BoolVarP(&options.showAll, "show-all-resources", "A", false, "Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency for namespace, deployment, controller, lable and pod OR --show-type --show-cpu --show-memory for node.")
 	cmd.Flags().StringVar(&options.serviceName, "service-name", "kubecost-cost-analyzer", "The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart.")
 	cmd.Flags().BoolVar(&options.useProxy, "use-proxy", false, "Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.")
 }
@@ -96,7 +94,6 @@ func (co *CostOptions) Complete() {
 		co.showSharedCost = true
 		co.showLoadBalancerCost = true
 		co.showAssetType = true
-		co.showRAMCost = true
 	}
 }
 

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -30,6 +30,9 @@ type CostOptions struct {
 	displayOptions
 }
 
+// With the addition of commands which query the assets API,
+// some of these don't apply to all commands. However, as they
+// are applied during the output, this shouldn't cause issues.
 type displayOptions struct {
 	showCPUCost          bool
 	showMemoryCost       bool
@@ -39,6 +42,8 @@ type displayOptions struct {
 	showEfficiency       bool
 	showSharedCost       bool
 	showLoadBalancerCost bool
+	showAssetType        bool
+	showRAMCost          bool
 }
 
 func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
@@ -52,7 +57,9 @@ func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
 	cmd.Flags().BoolVar(&options.showSharedCost, "show-shared", false, "show shared cost data")
 	cmd.Flags().BoolVar(&options.showLoadBalancerCost, "show-lb", false, "show load balancer cost data")
 	cmd.Flags().BoolVar(&options.showEfficiency, "show-efficiency", true, "show efficiency of cost alongside CPU and memory cost")
-	cmd.Flags().BoolVarP(&options.showAll, "show-all-resources", "A", false, "Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency.")
+	cmd.Flags().BoolVar(&options.showAssetType, "show-type", false, "show type of assets displayed.")
+	cmd.Flags().BoolVar(&options.showRAMCost, "show-ram", false, "show data for RAM cost")
+	cmd.Flags().BoolVarP(&options.showAll, "show-all-resources", "A", false, "Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency for namespace, deployment, controller, lable and pod OR --show-type --show-cpu --show-ram for node.")
 	cmd.Flags().StringVar(&options.serviceName, "service-name", "kubecost-cost-analyzer", "The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart.")
 	cmd.Flags().BoolVar(&options.useProxy, "use-proxy", false, "Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.")
 }
@@ -88,6 +95,8 @@ func (co *CostOptions) Complete() {
 		co.showNetworkCost = true
 		co.showSharedCost = true
 		co.showLoadBalancerCost = true
+		co.showAssetType = true
+		co.showRAMCost = true
 	}
 }
 

--- a/pkg/cmd/controller.go
+++ b/pkg/cmd/controller.go
@@ -71,6 +71,7 @@ func runCostController(ko *KubeOptions, no *CostOptionsController) error {
 		ServiceName:       no.serviceName,
 		Window:            no.window,
 		Aggregate:         "controller",
+		Accumulate:        "true",
 		UseProxy:          no.useProxy,
 	})
 	if err != nil {

--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -122,6 +122,7 @@ func NewCmdCost(
 	cmd.AddCommand(newCmdCostController(streams))
 	cmd.AddCommand(newCmdCostLabel(streams))
 	cmd.AddCommand(newCmdCostPod(streams))
+	cmd.AddCommand(newCmdCostNode(streams))
 	cmd.AddCommand(newCmdTUI(streams))
 	cmd.AddCommand(newCmdVersion(streams, GitCommit, GitBranch, GitState, GitSummary, BuildDate))
 

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -73,6 +73,7 @@ func runCostDeployment(ko *KubeOptions, no *CostOptionsDeployment) error {
 		ServiceName:       no.serviceName,
 		Window:            no.window,
 		Aggregate:         "deployment",
+		Accumulate:        "true",
 		UseProxy:          no.useProxy,
 	})
 	if err != nil {

--- a/pkg/cmd/label.go
+++ b/pkg/cmd/label.go
@@ -78,6 +78,7 @@ func runCostLabel(ko *KubeOptions, no *CostOptionsLabel) error {
 		ServiceName:       no.serviceName,
 		Window:            no.window,
 		Aggregate:         fmt.Sprintf("label:%s", no.queryLabel),
+		Accumulate:        "true",
 		UseProxy:          no.useProxy,
 	})
 	if err != nil {

--- a/pkg/cmd/namespace.go
+++ b/pkg/cmd/namespace.go
@@ -68,6 +68,7 @@ func runCostNamespace(ko *KubeOptions, no *CostOptionsNamespace) error {
 		ServiceName:       no.serviceName,
 		Window:            no.window,
 		Aggregate:         "namespace",
+		Accumulate:        "true",
 		UseProxy:          no.useProxy,
 	})
 	if err != nil {

--- a/pkg/cmd/node.go
+++ b/pkg/cmd/node.go
@@ -67,6 +67,7 @@ func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
 		KubecostNamespace: *ko.configFlags.Namespace,
 		ServiceName:       no.serviceName,
 		Window:            no.window,
+		Accumulate:        "true",
 		UseProxy:          no.useProxy,
 		FilterTypes:       "Node",
 	})

--- a/pkg/cmd/node.go
+++ b/pkg/cmd/node.go
@@ -62,16 +62,13 @@ func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
 	}
 
 	assets, err := query.QueryAssets(query.AssetParameters{
-		RestConfig:         ko.restConfig,
-		Ctx:                context.Background(),
-		KubecostNamespace:  *ko.configFlags.Namespace,
-		ServiceName:        no.serviceName,
-		Window:             no.window,
-		Aggregate:          "",
-		DisableAdjustments: false,
-		Accumulate:         true,
-		UseProxy:           no.useProxy,
-		FilterTypes:        "Node",
+		RestConfig:        ko.restConfig,
+		Ctx:               context.Background(),
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       no.serviceName,
+		Window:            no.window,
+		UseProxy:          no.useProxy,
+		FilterTypes:       "Node",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to query allocation API: %s", err)

--- a/pkg/cmd/node.go
+++ b/pkg/cmd/node.go
@@ -11,8 +11,8 @@ import (
 	"github.com/kubecost/kubectl-cost/pkg/query"
 )
 
-// CostOptionsNamespace contains the standard CostOptions and any
-// options specific to namespace queries.
+// CostOptionsNode contains the standard CostOptions and any
+// options specific to node queries.
 type CostOptionsNode struct {
 	CostOptions
 }
@@ -69,7 +69,7 @@ func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
 		Window:             no.window,
 		Aggregate:          "",
 		DisableAdjustments: false,
-		Accumulate:         false,
+		Accumulate:         true,
 		UseProxy:           no.useProxy,
 		FilterTypes:        "Node",
 	})
@@ -77,12 +77,7 @@ func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
 		return fmt.Errorf("failed to query allocation API: %s", err)
 	}
 
-	fmt.Println(currencyCode)
-	fmt.Println(assets)
-	atype := fmt.Sprintf("%T", assets)
-	fmt.Println(atype)
-
-	// Use allocations[0] because the query accumulates to a single result
+	// Use assets[0] because the query accumulates to a single result
 	writeAssetTable(ko.Out, "Node", assets[0], no.displayOptions, currencyCode, !no.isHistorical)
 
 	return nil

--- a/pkg/cmd/node.go
+++ b/pkg/cmd/node.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubecost/kubectl-cost/pkg/query"
+)
+
+// CostOptionsNamespace contains the standard CostOptions and any
+// options specific to namespace queries.
+type CostOptionsNode struct {
+	CostOptions
+}
+
+func newCmdCostNode(streams genericclioptions.IOStreams) *cobra.Command {
+	kubeO := NewKubeOptions(streams)
+	assetsO := &CostOptionsNode{}
+
+	cmd := &cobra.Command{
+		Use:   "node",
+		Short: "view cost information by nodes",
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := kubeO.Complete(c, args); err != nil {
+				return err
+			}
+			if err := kubeO.Validate(); err != nil {
+				return err
+			}
+
+			assetsO.CostOptions.Complete()
+
+			if err := assetsO.CostOptions.Validate(); err != nil {
+				return err
+			}
+
+			return runCostNode(kubeO, assetsO)
+		},
+	}
+
+	addCostOptionsFlags(cmd, &assetsO.CostOptions)
+	addKubeOptionsFlags(cmd, kubeO)
+
+	return cmd
+}
+
+func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
+
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:        ko.restConfig,
+		Ctx:               context.Background(),
+		KubecostNamespace: *ko.configFlags.Namespace,
+		ServiceName:       no.serviceName,
+		UseProxy:          no.useProxy,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get currency code: %s", err)
+	}
+
+	assets, err := query.QueryAssets(query.AssetParameters{
+		RestConfig:         ko.restConfig,
+		Ctx:                context.Background(),
+		KubecostNamespace:  *ko.configFlags.Namespace,
+		ServiceName:        no.serviceName,
+		Window:             no.window,
+		Aggregate:          "",
+		DisableAdjustments: false,
+		Accumulate:         false,
+		UseProxy:           no.useProxy,
+		FilterTypes:        "Node",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to query allocation API: %s", err)
+	}
+
+	fmt.Println(currencyCode)
+	fmt.Println(assets)
+	atype := fmt.Sprintf("%T", assets)
+	fmt.Println(atype)
+
+	// Use allocations[0] because the query accumulates to a single result
+	writeAssetTable(ko.Out, "Node", assets[0], no.displayOptions, currencyCode, !no.isHistorical)
+
+	return nil
+}

--- a/pkg/cmd/output.go
+++ b/pkg/cmd/output.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 
 	"github.com/kubecost/cost-model/pkg/kubecost"
+	"github.com/kubecost/kubectl-cost/pkg/query"
 )
 
 const (
@@ -23,6 +24,10 @@ const (
 	NetworkCol          = "Network"
 	SharedCol           = "Shared Cost"
 	LoadBalancerCol     = "Load Balancer Cost"
+	NameCol             = "Name"
+	TypeCol             = "Asset Type"
+	CPUCostCol          = "CPU Cost"
+	RAMCostCol          = "RAM Cost"
 )
 
 func formatFloat(f float64) string {
@@ -335,6 +340,169 @@ func makeAllocationTable(allocationType string, allocations map[string]kubecost.
 	if opts.showEfficiency {
 		footerRow = append(footerRow, "")
 	}
+
+	t.AppendFooter(footerRow)
+
+	return t
+}
+
+func writeAssetTable(out io.Writer, assetType string, assets map[string]query.Assets, opts displayOptions, currencyCode string, projectToMonthlyRate bool) {
+	t := makeAssetTable(assetType, assets, opts, currencyCode, projectToMonthlyRate)
+
+	t.SetOutputMirror(out)
+	t.Render()
+}
+
+func makeAssetTable(assetType string, assets map[string]query.Assets, opts displayOptions, currencyCode string, projectToMonthlyRate bool) table.Writer {
+	t := table.NewWriter()
+
+	columnConfigs := []table.ColumnConfig{}
+
+	columnConfigs = append(columnConfigs, table.ColumnConfig{
+		Name:      ClusterCol,
+		AutoMerge: true,
+	})
+
+	columnConfigs = append(columnConfigs, table.ColumnConfig{
+		Name: NameCol,
+	})
+
+	if opts.showAssetType {
+		columnConfigs = append(columnConfigs, table.ColumnConfig{
+			Name: TypeCol,
+		})
+	}
+
+	if opts.showCPUCost {
+		columnConfigs = append(columnConfigs, table.ColumnConfig{
+			Name:        CPUCostCol,
+			Align:       text.AlignRight,
+			AlignFooter: text.AlignRight,
+		})
+	}
+
+	if opts.showRAMCost {
+		columnConfigs = append(columnConfigs, table.ColumnConfig{
+			Name:        RAMCostCol,
+			Align:       text.AlignRight,
+			AlignFooter: text.AlignRight,
+		})
+	}
+
+	if projectToMonthlyRate {
+		columnConfigs = append(columnConfigs, table.ColumnConfig{
+			Name:        "Monthly Cost",
+			Align:       text.AlignRight,
+			AlignFooter: text.AlignRight,
+		})
+	} else {
+		columnConfigs = append(columnConfigs, table.ColumnConfig{
+			Name:        "Total Cost",
+			Align:       text.AlignRight,
+			AlignFooter: text.AlignRight,
+		})
+	}
+
+	t.SetColumnConfigs(columnConfigs)
+
+	headerRow := table.Row{}
+
+	headerRow = append(headerRow, ClusterCol)
+
+	headerRow = append(headerRow, NameCol)
+
+	if opts.showAssetType {
+		headerRow = append(headerRow, TypeCol)
+	}
+
+	if opts.showCPUCost {
+		headerRow = append(headerRow, CPUCostCol)
+	}
+
+	if opts.showRAMCost {
+		headerRow = append(headerRow, RAMCostCol)
+	}
+
+	if projectToMonthlyRate {
+		headerRow = append(headerRow, "Monthly Cost")
+	} else {
+		headerRow = append(headerRow, "Total Cost")
+	}
+
+	t.AppendHeader(headerRow)
+
+	var summedCost float64
+	var summedCPUCost float64
+	var summedRAMCost float64
+
+	for _, asset := range assets {
+
+		// This variable exists to scale costs by the active window
+		var histScaleFactor float64 = 1
+
+		if projectToMonthlyRate {
+
+			// scale by minutes per month divided by duration
+			// of window in minutes to get projected monthly cost.
+			// Note that this approach assumes the window costs will apply
+			// through the ENTIRE projected month, no matter the window size.
+			histScaleFactor = 43200 / asset.Minutes
+
+		}
+
+		name := asset.Properties.Name
+		cluster := asset.Properties.Cluster
+
+		assetRow := table.Row{}
+
+		assetRow = append(assetRow, cluster)
+
+		assetRow = append(assetRow, name)
+
+		if opts.showAssetType {
+			assetType := asset.NodeType
+			assetRow = append(assetRow, assetType)
+		}
+
+		if opts.showCPUCost {
+			adjCPUCost := asset.CPUCost * histScaleFactor
+			assetRow = append(assetRow, formatFloat(adjCPUCost))
+			summedCPUCost += adjCPUCost
+		}
+
+		if opts.showRAMCost {
+			adjRAMCost := asset.RAMCost * histScaleFactor
+			assetRow = append(assetRow, formatFloat(adjRAMCost))
+			summedRAMCost += adjRAMCost
+		}
+
+		adjTotalCost := asset.TotalCost * histScaleFactor
+		cumulativeCost := formatFloat(adjTotalCost)
+		assetRow = append(assetRow, cumulativeCost)
+
+		t.AppendRow(assetRow)
+		summedCost += adjTotalCost
+	}
+
+	footerRow := table.Row{}
+
+	footerRow = append(footerRow, "SUMMED")
+
+	footerRow = append(footerRow, "")
+
+	if opts.showAssetType {
+		footerRow = append(footerRow, "")
+	}
+
+	if opts.showCPUCost {
+		footerRow = append(footerRow, fmt.Sprintf("%s %s", currencyCode, formatFloat(summedCPUCost)))
+	}
+
+	if opts.showRAMCost {
+		footerRow = append(footerRow, fmt.Sprintf("%s %s", currencyCode, formatFloat(summedRAMCost)))
+	}
+
+	footerRow = append(footerRow, fmt.Sprintf("%s %s", currencyCode, formatFloat(summedCost)))
 
 	t.AppendFooter(footerRow)
 

--- a/pkg/cmd/output.go
+++ b/pkg/cmd/output.go
@@ -25,7 +25,7 @@ const (
 	SharedCol           = "Shared Cost"
 	LoadBalancerCol     = "Load Balancer Cost"
 	NameCol             = "Name"
-	TypeCol             = "Asset Type"
+	AssetTypeCol        = "Asset Type"
 	CPUCostCol          = "CPU Cost"
 	RAMCostCol          = "RAM Cost"
 )
@@ -346,14 +346,14 @@ func makeAllocationTable(allocationType string, allocations map[string]kubecost.
 	return t
 }
 
-func writeAssetTable(out io.Writer, assetType string, assets map[string]query.Assets, opts displayOptions, currencyCode string, projectToMonthlyRate bool) {
+func writeAssetTable(out io.Writer, assetType string, assets map[string]query.AssetNode, opts displayOptions, currencyCode string, projectToMonthlyRate bool) {
 	t := makeAssetTable(assetType, assets, opts, currencyCode, projectToMonthlyRate)
 
 	t.SetOutputMirror(out)
 	t.Render()
 }
 
-func makeAssetTable(assetType string, assets map[string]query.Assets, opts displayOptions, currencyCode string, projectToMonthlyRate bool) table.Writer {
+func makeAssetTable(assetType string, assets map[string]query.AssetNode, opts displayOptions, currencyCode string, projectToMonthlyRate bool) table.Writer {
 	t := table.NewWriter()
 
 	columnConfigs := []table.ColumnConfig{}
@@ -369,7 +369,7 @@ func makeAssetTable(assetType string, assets map[string]query.Assets, opts displ
 
 	if opts.showAssetType {
 		columnConfigs = append(columnConfigs, table.ColumnConfig{
-			Name: TypeCol,
+			Name: AssetTypeCol,
 		})
 	}
 
@@ -381,7 +381,7 @@ func makeAssetTable(assetType string, assets map[string]query.Assets, opts displ
 		})
 	}
 
-	if opts.showRAMCost {
+	if opts.showMemoryCost {
 		columnConfigs = append(columnConfigs, table.ColumnConfig{
 			Name:        RAMCostCol,
 			Align:       text.AlignRight,
@@ -412,14 +412,14 @@ func makeAssetTable(assetType string, assets map[string]query.Assets, opts displ
 	headerRow = append(headerRow, NameCol)
 
 	if opts.showAssetType {
-		headerRow = append(headerRow, TypeCol)
+		headerRow = append(headerRow, AssetTypeCol)
 	}
 
 	if opts.showCPUCost {
 		headerRow = append(headerRow, CPUCostCol)
 	}
 
-	if opts.showRAMCost {
+	if opts.showMemoryCost {
 		headerRow = append(headerRow, RAMCostCol)
 	}
 
@@ -470,7 +470,7 @@ func makeAssetTable(assetType string, assets map[string]query.Assets, opts displ
 			summedCPUCost += adjCPUCost
 		}
 
-		if opts.showRAMCost {
+		if opts.showMemoryCost {
 			adjRAMCost := asset.RAMCost * histScaleFactor
 			assetRow = append(assetRow, formatFloat(adjRAMCost))
 			summedRAMCost += adjRAMCost
@@ -498,7 +498,7 @@ func makeAssetTable(assetType string, assets map[string]query.Assets, opts displ
 		footerRow = append(footerRow, fmt.Sprintf("%s %s", currencyCode, formatFloat(summedCPUCost)))
 	}
 
-	if opts.showRAMCost {
+	if opts.showMemoryCost {
 		footerRow = append(footerRow, fmt.Sprintf("%s %s", currencyCode, formatFloat(summedRAMCost)))
 	}
 

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -71,6 +71,7 @@ func runCostPod(ko *KubeOptions, no *CostOptionsPod) error {
 		ServiceName:       no.serviceName,
 		Window:            no.window,
 		Aggregate:         "pod",
+		Accumulate:        "true",
 		UseProxy:          no.useProxy,
 	})
 	if err != nil {

--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -228,6 +228,7 @@ func runTUI(ko *KubeOptions, do displayOptions) error {
 				ServiceName:       "kubecost-cost-analyzer",
 				Window:            windowOptions[windowIndex],
 				Aggregate:         aggregation,
+				Accumulate:        "true",
 				UseProxy:          true,
 			})
 

--- a/pkg/query/allocation.go
+++ b/pkg/query/allocation.go
@@ -81,6 +81,7 @@ type AllocationParameters struct {
 	ServiceName       string
 	Window            string
 	Aggregate         string
+	Accumulate        string
 	UseProxy          bool
 }
 
@@ -93,7 +94,7 @@ func QueryAllocation(p AllocationParameters) ([]map[string]kubecost.Allocation, 
 		// if we set this to false, output would be
 		// per-day (we could use it in a more
 		// complicated way to build in-terminal charts)
-		"accumulate": "true",
+		"accumulate": p.Accumulate,
 		"window":     p.Window,
 	}
 

--- a/pkg/query/assetsapi.go
+++ b/pkg/query/assetsapi.go
@@ -1,0 +1,104 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubecost/cost-model/pkg/kubecost"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type assetResponse struct {
+	Code int                 `json:"code"`
+	Data []map[string]Assets `json:"data"`
+}
+
+type AssetParameters struct {
+	RestConfig *rest.Config
+	Ctx        context.Context
+
+	KubecostNamespace  string
+	ServiceName        string
+	Window             string
+	Aggregate          string
+	DisableAdjustments bool
+	Accumulate         bool
+	UseProxy           bool
+	FilterTypes        string
+}
+
+// QueryAssets queries /model/assets by proxying a request to Kubecost
+// through the Kubernetes API server if useProxy is true or, if it isn't, by
+// temporarily port forwarding to a Kubecost pod.
+func QueryAssets(p AssetParameters) ([]map[string]Assets, error) {
+
+	// aggregate, accumulate, and disableAdjustments are hardcoded;
+	// as other asset types are added in to be filtered by, this may change,
+	// but for now anything beyond the defaults isn't needed.
+
+	requestParams := map[string]string{
+		"window":             p.Window,
+		"aggregate":          "",
+		"accumulate":         "false",
+		"disableAdjustments": "true",
+		"filterTypes":        p.FilterTypes,
+	}
+
+	if p.Aggregate != "" {
+		requestParams["aggregate"] = p.Aggregate
+	}
+
+	var bytes []byte
+	var err error
+	if p.UseProxy {
+		clientset, err := kubernetes.NewForConfig(p.RestConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create clientset: %s", err)
+		}
+
+		bytes, err = clientset.CoreV1().Services(p.KubecostNamespace).ProxyGet("", p.ServiceName, "9090", "/model/assets", requestParams).DoRaw(p.Ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
+		}
+	} else {
+		bytes, err = portForwardedQueryService(p.RestConfig, p.KubecostNamespace, p.ServiceName, "model/assets", requestParams, p.Ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to port forward query: %s", err)
+		}
+	}
+
+	var ar assetResponse
+	err = json.Unmarshal(bytes, &ar)
+	if err != nil {
+		return ar.Data, fmt.Errorf("failed to unmarshal allocation response: %s", err)
+	}
+
+	return ar.Data, nil
+}
+
+type Assets struct {
+	Type         string                   `json:"type"`
+	Properties   kubecost.AssetProperties `json:"properties"`
+	Labels       kubecost.AssetLabels     `json:"labels"`
+	Start        string                   `json:"start"`
+	End          string                   `json:"end"`
+	Minutes      float64                  `json:"minutes"`
+	NodeType     string                   `json:"nodeType"`
+	CpuCores     float64                  `json:"cpuCores"`
+	RamBytes     float64                  `json:"ramBytes"`
+	CPUCoreHours float64                  `json:"cpuCoreHours"`
+	RAMByteHours float64                  `json:"ramByteHours"`
+	GPUHours     float64                  `json:"GPUHours"`
+	CPUBreakdown kubecost.Breakdown       `json:"cpuBreakdown"`
+	GPUBreakdown kubecost.Breakdown       `json:"ramBreakdown"`
+	Preemptible  float64                  `json:"preemptible"`
+	Discount     float64                  `json:"discount"`
+	CPUCost      float64                  `json:"cpuCost"`
+	GPUCost      float64                  `json:"gpuCost"`
+	GPUCount     float64                  `json:"gpuCount"`
+	RAMCost      float64                  `json:"ramCost"`
+	Adjustment   float64                  `json:"adjustment"`
+	TotalCost    float64                  `json:"totalCost"`
+}

--- a/pkg/query/assetsapi.go
+++ b/pkg/query/assetsapi.go
@@ -11,8 +11,8 @@ import (
 )
 
 type assetResponse struct {
-	Code int                 `json:"code"`
-	Data []map[string]Assets `json:"data"`
+	Code int                    `json:"code"`
+	Data []map[string]AssetNode `json:"data"`
 }
 
 type AssetParameters struct {
@@ -32,7 +32,7 @@ type AssetParameters struct {
 // QueryAssets queries /model/assets by proxying a request to Kubecost
 // through the Kubernetes API server if useProxy is true or, if it isn't, by
 // temporarily port forwarding to a Kubecost pod.
-func QueryAssets(p AssetParameters) ([]map[string]Assets, error) {
+func QueryAssets(p AssetParameters) ([]map[string]AssetNode, error) {
 
 	// aggregate, accumulate, and disableAdjustments are hardcoded;
 	// as other asset types are added in to be filtered by, this may change,
@@ -78,7 +78,7 @@ func QueryAssets(p AssetParameters) ([]map[string]Assets, error) {
 	return ar.Data, nil
 }
 
-type Assets struct {
+type AssetNode struct {
 	Type         string                   `json:"type"`
 	Properties   kubecost.AssetProperties `json:"properties"`
 	Labels       kubecost.AssetLabels     `json:"labels"`

--- a/pkg/query/assetsapi.go
+++ b/pkg/query/assetsapi.go
@@ -42,7 +42,7 @@ func QueryAssets(p AssetParameters) ([]map[string]AssetNode, error) {
 		"window":             p.Window,
 		"aggregate":          "",
 		"accumulate":         "true",
-		"disableAdjustments": "true",
+		"disableAdjustments": "false",
 		"filterTypes":        p.FilterTypes,
 	}
 

--- a/pkg/query/assetsapi.go
+++ b/pkg/query/assetsapi.go
@@ -24,7 +24,7 @@ type AssetParameters struct {
 	Window             string
 	Aggregate          string
 	DisableAdjustments bool
-	Accumulate         bool
+	Accumulate         string
 	UseProxy           bool
 	FilterTypes        string
 }
@@ -39,11 +39,9 @@ func QueryAssets(p AssetParameters) ([]map[string]AssetNode, error) {
 	// but for now anything beyond isn't needed.
 
 	requestParams := map[string]string{
-		"window":             p.Window,
-		"aggregate":          "",
-		"accumulate":         "true",
-		"disableAdjustments": "false",
-		"filterTypes":        p.FilterTypes,
+		"window":      p.Window,
+		"accumulate":  p.Accumulate,
+		"filterTypes": p.FilterTypes,
 	}
 
 	if p.Aggregate != "" {

--- a/pkg/query/assetsapi.go
+++ b/pkg/query/assetsapi.go
@@ -36,12 +36,12 @@ func QueryAssets(p AssetParameters) ([]map[string]Assets, error) {
 
 	// aggregate, accumulate, and disableAdjustments are hardcoded;
 	// as other asset types are added in to be filtered by, this may change,
-	// but for now anything beyond the defaults isn't needed.
+	// but for now anything beyond isn't needed.
 
 	requestParams := map[string]string{
 		"window":             p.Window,
 		"aggregate":          "",
-		"accumulate":         "false",
+		"accumulate":         "true",
 		"disableAdjustments": "true",
 		"filterTypes":        p.FilterTypes,
 	}


### PR DESCRIPTION
Ref https://github.com/kubecost/kubectl-cost/issues/78.

Adds node subcommand which generates a cost table filtered by individual nodes. Also implements `QueryAssets` and `writeAssetTable` which can be modified to be used for other asset types in the future.

Sample output:
```kubectl cost node --show-ram --show-type --historical --show-cpu
+-------------+---------------------------------------------+------------+--------------+--------------+--------------+
| CLUSTER     | NAME                                        | ASSET TYPE | CPU COST     | RAM COST     | TOTAL COST   |
+-------------+---------------------------------------------+------------+--------------+--------------+--------------+
| cluster-one | gke-test-cluster-pool-1-9bb98ef8-cf3j       | e2-medium  |     0.540200 |     0.278558 |     0.818758 |
|             | gke-test-cluster-pool-1-9bb98ef8-kdsf       | e2-medium  |     0.540200 |     0.278558 |     0.818758 |
|             | gke-test-cluster-default-pool-d6266c7c-dqms | e2-medium  |     0.540200 |     0.278557 |     0.818758 |
|             | gke-test-cluster-pool-1-9bb98ef8-3w6g       | e2-medium  |     0.540200 |     0.278557 |     0.818758 |
+-------------+---------------------------------------------+------------+--------------+--------------+--------------+
| SUMMED      |                                             |            | USD 2.160800 | USD 1.114230 | USD 3.275032 |
+-------------+---------------------------------------------+------------+--------------+--------------+--------------+```

Tested locally and cross-referenced with kubecost Assets view.