### PR TITLE
Add long explanation, with install instructions

### DIFF
--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -104,8 +104,26 @@ func NewCmdCost(
 	BuildDate string,
 ) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "cost",
-		Short:        "View cluster cost information.",
+		Use:   "cost",
+		Short: "View cluster cost information.",
+		Long: `
+kubectl-cost is a CLI frontend for Kubecost, a highly accurate provider of
+Kubernetes cluster cost information and optimization opportunities.
+
+kubectl-cost requires Kubecost to be installed in your Kubernetes cluster. Make
+sure to check out the examples and full set of flags (--help) if you have a
+non-default Kubecost install, like running in a custom namespace!
+
+If you don't have Kubecost installed yet, all it takes is Helm and two minutes:
+
+kubectl create namespace kubecost
+helm repo add kubecost https://kubecost.github.io/cost-analyzer/
+helm install \
+    kubecost \
+    kubecost/cost-analyzer \
+    --namespace kubecost \
+    --set kubecostToken="WljaGFdC5jctl20df98"
+`,
 		Example:      fmt.Sprintf(costExample, "kubectl"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {


### PR DESCRIPTION
## What does this PR change?

It was sometimes unclear that Kubecost has to be installed in the target
cluster for kubectl-cost to function. This commit adds two things to
`kubectl cost help`:
- clarification of the need for Kubecost to be installed
- a pre-formatted Helm install for Kubecost!

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Improved help information (with Kubecost install instructions) when running `kubectl cost help`

## Links to Issues or ZD tickets this PR addresses or fixes

- N/A

## How was this PR tested?

Locally by running `kubectl cost help` and checking the output!

## Have you made an update to documentation?

N/A