### PR TITLE
Fix govvv install step in build-release workflow

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install govvv
         run: |
-          go get github.com/ahmetb/govvv@master
+          go install github.com/ahmetb/govvv@master
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## What does this PR change?

Installing with `go get` is now deprecated, so we have to use `go install`
in the build-release workflow instead.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

Locally with `act` (https://github.com/nektos/act) through the `go install` step. This is the step that failed in https://github.com/kubecost/kubectl-cost/actions/runs/2265123192.

## Have you made an update to documentation?

N/A