### PR TITLE
Add support for custom namespace/service to TUI

### DIFF
--- a/pkg/cmd/controller.go
+++ b/pkg/cmd/controller.go
@@ -54,25 +54,21 @@ func newCmdCostController(streams genericclioptions.IOStreams) *cobra.Command {
 func runCostController(ko *KubeOptions, no *CostOptionsController) error {
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	allocations, err := query.QueryAllocation(query.AllocationParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		Window:            no.window,
-		Aggregate:         "controller",
-		Accumulate:        "true",
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		Window:              no.window,
+		Aggregate:           "controller",
+		Accumulate:          "true",
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to query allocation API: %s", err)

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -56,25 +56,21 @@ func newCmdCostDeployment(streams genericclioptions.IOStreams) *cobra.Command {
 func runCostDeployment(ko *KubeOptions, no *CostOptionsDeployment) error {
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	allocations, err := query.QueryAllocation(query.AllocationParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		Window:            no.window,
-		Aggregate:         "deployment",
-		Accumulate:        "true",
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		Window:              no.window,
+		Aggregate:           "deployment",
+		Accumulate:          "true",
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to query allocation API: %s", err)

--- a/pkg/cmd/label.go
+++ b/pkg/cmd/label.go
@@ -61,25 +61,21 @@ func newCmdCostLabel(streams genericclioptions.IOStreams) *cobra.Command {
 func runCostLabel(ko *KubeOptions, no *CostOptionsLabel) error {
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	allocations, err := query.QueryAllocation(query.AllocationParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		Window:            no.window,
-		Aggregate:         fmt.Sprintf("label:%s", no.queryLabel),
-		Accumulate:        "true",
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		Window:              no.window,
+		Aggregate:           fmt.Sprintf("label:%s", no.queryLabel),
+		Accumulate:          "true",
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to query allocation API: %s", err)

--- a/pkg/cmd/namespace.go
+++ b/pkg/cmd/namespace.go
@@ -51,25 +51,21 @@ func newCmdCostNamespace(streams genericclioptions.IOStreams) *cobra.Command {
 func runCostNamespace(ko *KubeOptions, no *CostOptionsNamespace) error {
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	allocations, err := query.QueryAllocation(query.AllocationParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		Window:            no.window,
-		Aggregate:         "namespace",
-		Accumulate:        "true",
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		Window:              no.window,
+		Aggregate:           "namespace",
+		Accumulate:          "true",
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to query allocation API: %s", err)

--- a/pkg/cmd/node.go
+++ b/pkg/cmd/node.go
@@ -51,25 +51,21 @@ func newCmdCostNode(streams genericclioptions.IOStreams) *cobra.Command {
 func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	assets, err := query.QueryAssets(query.AssetParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		Window:            no.window,
-		Accumulate:        "true",
-		UseProxy:          no.useProxy,
-		FilterTypes:       "Node",
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		Window:              no.window,
+		Accumulate:          "true",
+		FilterTypes:         "Node",
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to query allocation API: %s", err)

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -54,25 +54,21 @@ func newCmdCostPod(streams genericclioptions.IOStreams) *cobra.Command {
 func runCostPod(ko *KubeOptions, no *CostOptionsPod) error {
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get currency code: %s", err)
 	}
 
 	allocations, err := query.QueryAllocation(query.AllocationParameters{
-		RestConfig:        ko.restConfig,
-		Ctx:               context.Background(),
-		KubecostNamespace: *ko.configFlags.Namespace,
-		ServiceName:       no.serviceName,
-		Window:            no.window,
-		Aggregate:         "pod",
-		Accumulate:        "true",
-		UseProxy:          no.useProxy,
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		Window:              no.window,
+		Aggregate:           "pod",
+		Accumulate:          "true",
+		QueryBackendOptions: no.QueryBackendOptions,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to query allocation API: %s", err)

--- a/pkg/query/allocation.go
+++ b/pkg/query/allocation.go
@@ -77,12 +77,11 @@ type AllocationParameters struct {
 	RestConfig *rest.Config
 	Ctx        context.Context
 
-	KubecostNamespace string
-	ServiceName       string
-	Window            string
-	Aggregate         string
-	Accumulate        string
-	UseProxy          bool
+	Window     string
+	Aggregate  string
+	Accumulate string
+
+	QueryBackendOptions
 }
 
 // QueryAllocation queries /model/allocation by proxying a request to Kubecost

--- a/pkg/query/assetsapi.go
+++ b/pkg/query/assetsapi.go
@@ -19,14 +19,13 @@ type AssetParameters struct {
 	RestConfig *rest.Config
 	Ctx        context.Context
 
-	KubecostNamespace  string
-	ServiceName        string
 	Window             string
 	Aggregate          string
 	DisableAdjustments bool
 	Accumulate         string
-	UseProxy           bool
 	FilterTypes        string
+
+	QueryBackendOptions
 }
 
 // QueryAssets queries /model/assets by proxying a request to Kubecost

--- a/pkg/query/config.go
+++ b/pkg/query/config.go
@@ -19,9 +19,7 @@ type CurrencyCodeParameters struct {
 	RestConfig *rest.Config
 	Ctx        context.Context
 
-	KubecostNamespace string
-	ServiceName       string
-	UseProxy          bool
+	QueryBackendOptions
 }
 
 func QueryCurrencyCode(p CurrencyCodeParameters) (string, error) {

--- a/pkg/query/options.go
+++ b/pkg/query/options.go
@@ -1,0 +1,19 @@
+package query
+
+// QueryBackendOptions holds common options for managing the query backend used
+// by kubectl-cost, like service name, namespace, etc.
+type QueryBackendOptions struct {
+	// If set, will proxy a request through the K8s API server
+	// instead of port forwarding.
+	UseProxy bool
+
+	// The name of the cost-analyzer service in the cluster,
+	// in case user is running a non-standard name (like the
+	// staging helm chart). Combines with
+	// commonOptions.configFlags.Namespace to direct the API
+	// request.
+	ServiceName string
+
+	// The namespace in which Kubecost is running
+	KubecostNamespace string
+}


### PR DESCRIPTION
## What does this PR change?

This is done by introducing a new common QueryBackendOptions struct which
contains all configuration information necessary to select the correct
backend to execute API queries against. The new TUI options embeds this
struct just like all other commands, and core query logic has been
updated to use QueryBackendOptions.

## Does this PR rely on any other PRs?

- N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- `kubectl cost tui` supports the `--kubecost-namespace` and `--service-name` flags.

## Links to Issues or ZD tickets this PR addresses or fixes

- Closes https://github.com/kubecost/kubectl-cost/issues/105

## How was this PR tested?

Tested by running TUI with custom flags. Confirmed no regression by
running integration.sh

## Have you made an update to documentation?

N/A