### PR TITLE
add aliases for k8s resources

### DIFF
--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -27,6 +27,7 @@ func newCmdCostDeployment(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deployment",
 		Short: "view cost information aggregated by deployment",
+		Aliases: []string{"deploy"},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := kubeO.Complete(c, args); err != nil {
 				return err

--- a/pkg/cmd/namespace.go
+++ b/pkg/cmd/namespace.go
@@ -24,6 +24,7 @@ func newCmdCostNamespace(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace",
 		Short: "view cost information aggregated by namespace",
+		Aliases: []string{"ns"},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := kubeO.Complete(c, args); err != nil {
 				return err

--- a/pkg/cmd/node.go
+++ b/pkg/cmd/node.go
@@ -24,6 +24,7 @@ func newCmdCostNode(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "view cost information by nodes",
+		Aliases: []string{"no"},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := kubeO.Complete(c, args); err != nil {
 				return err

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -26,6 +26,7 @@ func newCmdCostPod(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pod",
 		Short: "view cost information aggregated by pod",
+		Aliases: []string{"po"},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := kubeO.Complete(c, args); err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Anurag <contact.anurag7@gmail.com>

## What does this PR change?
- This PR adds the aliases mentioned in #108 
- Aliases match the short names present in `kubectl api-resources` 

## Does this PR rely on any other PRs?

- No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- This will save some time as one will avoid extra typing

## Links to Issues or ZD tickets this PR addresses or fixes

- #108 
- https://kubecost.zendesk.com/agent/tickets/1956

Closes #108 


## How was this PR tested?
- I have tested this PR locally on my k3s cluster

## Have you made an update to documentation?
- No 
