### PR TITLE
Only port-forward to Ready Pods

### DIFF
--- a/pkg/query/podutil.go
+++ b/pkg/query/podutil.go
@@ -1,0 +1,48 @@
+package query
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// Code in this file taken from:  https://github.com/kubernetes/kubernetes/blob/b1e2af45e4ff126fcbcffa2e66ed36502103be7b/pkg/api/v1/pod/util.go#L299-L361 to avoid importing all of k/k
+
+// IsPodReady returns true if a pod is ready; false otherwise.
+func isPodReady(pod *v1.Pod) bool {
+	return isPodReadyConditionTrue(pod.Status)
+}
+
+// IsPodReadyConditionTrue returns true if a pod is ready; false otherwise.
+func isPodReadyConditionTrue(status v1.PodStatus) bool {
+	condition := getPodReadyCondition(status)
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
+// GetPodReadyCondition extracts the pod ready condition from the given status and returns that.
+// Returns nil if the condition is not present.
+func getPodReadyCondition(status v1.PodStatus) *v1.PodCondition {
+	_, condition := getPodCondition(&status, v1.PodReady)
+	return condition
+}
+
+// GetPodCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+func getPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	return getPodConditionFromList(status.Conditions, conditionType)
+}
+
+// GetPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+func getPodConditionFromList(conditions []v1.PodCondition, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
+		}
+	}
+	return -1, nil
+}

--- a/pkg/query/portforward.go
+++ b/pkg/query/portforward.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+
+	"github.com/kubecost/opencost/pkg/log"
 )
 
 // reference: https://stackoverflow.com/questions/41545123/how-to-get-pods-under-the-service-with-client-go-the-client-library-of-kubernete
@@ -56,7 +58,23 @@ func portForwardedQueryService(restConfig *rest.Config, namespace, serviceName, 
 		return nil, fmt.Errorf("no pods for service %s in namespace %s", serviceName, namespace)
 	}
 
-	podToForward := pods.Items[0]
+	// It's possible that there can be pods matching the service which are in a
+	// non-Ready (e.g. Error, Completed) state. Make sure we select a Ready pod.
+	var podToForward *corev1.Pod
+	for _, pod := range pods.Items {
+		pod := pod
+		log.Debugf("checking readiness of '%s'", pod.Name)
+		if isPodReady(&pod) {
+			podToForward = &pod
+			break
+		}
+	}
+
+	if podToForward == nil {
+		return nil, fmt.Errorf("couldn't find a Pod which is Ready to serve the query")
+	}
+
+	log.Debugf("selected pod to forward: %s", podToForward.Name)
 
 	// Second: build the port forwarding config
 	// https://stackoverflow.com/questions/59027739/upgrading-connection-error-in-port-forwarding-via-client-go


### PR DESCRIPTION
## What does this PR change?

Tested on a cluster with spot nodes, which causes the
kubecost-cost-analyzer pod to occasionally die in a Completed state,
which cannot serve requests. This change makes kubectl-cost
work correctly in that environment.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- kubectl cost will only port-forward to Pods in a Ready state. Previously, kubectl cost could fail with a panic if the first cost-analyzer pod listed by the equivalent of `kubectl get pods` was in a non-Ready state (like Error or Completed).

## How was this PR tested?

Against a cluster with cost-analyzer pods in a Completed state. Before the change, `kubectl cost` panicked. Afterward, it functions correctly.