### PR TITLE
adding environment variable KUBECTL_COST_USE_PROXY to set the --use-proxy behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ The following flags modify the behavior of the subcommands:
     --service-port int               The port of the service at which the APIs are running. If using OpenCost, you may want to set this to 9003. (default 9090)
     --allocation-path string         URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute' (default "/model/allocation")
 -N, --kubecost-namespace string   The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace. (default "kubecost")
-    --use-proxy                   Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.
 ```
 
 
@@ -221,7 +220,7 @@ The following flags modify the behavior of the subcommands:
 
 In order to provide a seamless experience for standard Kubernetes configurations, `kubectl-cost` temporarily forwards a port on your system to a Kubecost pod and uses that port to proxy a request. The port will only be bound to `localhost` and will only be open for the duration of the API request.
 
-If you don't want a port to be temporarily forwarded, there is legacy behavior exposed with the flag `--use-proxy` that will instead use the Kubernetes API server to proxy a request to Kubecost. This behavior has its own pitfalls, especially with security policies that would prevent the API server from communicating with services. If you'd like to test this behavior, to make sure it will work with your cluster:
+If you don't want a port to be temporarily forwarded, there is legacy behavior exposed with the environment variable `KUBECTL_COST_USE_PROXY`, which when set to `true` will instead use the Kubernetes API server to proxy a request to Kubecost. This behavior has its own pitfalls, especially with security policies that would prevent the API server from communicating with services. If you'd like to test this behavior, to make sure it will work with your cluster:
 
 ``` sh
 kubectl proxy --port 8080
@@ -234,7 +233,7 @@ curl -G 'http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost
 
 > If you are running an old version of Kubecost, you may have to replace `tcp-model` with `model`
 
-If that `curl` succeeds, `--use-proxy` should work for you.
+If that `curl` succeeds, `KUBECTL_COST_USE_PROXY` set to true should work for you.
 
 Otherwise:
 - There may be an underlying problem with your Kubecost install, try `kubectl port-forward`ing the `kubecost-cost-analyzer` service, port 9090, and querying [one of our APIs](https://github.com/kubecost/docs/blob/master/apis.md).

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The following flags modify the behavior of the subcommands:
     --service-port int               The port of the service at which the APIs are running. If using OpenCost, you may want to set this to 9003. (default 9090)
     --allocation-path string         URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute' (default "/model/allocation")
 -N, --kubecost-namespace string   The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace. (default "kubecost")
+    --use-proxy                   Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.
 ```
 
 
@@ -220,7 +221,7 @@ The following flags modify the behavior of the subcommands:
 
 In order to provide a seamless experience for standard Kubernetes configurations, `kubectl-cost` temporarily forwards a port on your system to a Kubecost pod and uses that port to proxy a request. The port will only be bound to `localhost` and will only be open for the duration of the API request.
 
-If you don't want a port to be temporarily forwarded, there is legacy behavior exposed with the environment variable `KUBECTL_COST_USE_PROXY`, which when set to `true` will instead use the Kubernetes API server to proxy a request to Kubecost. This behavior has its own pitfalls, especially with security policies that would prevent the API server from communicating with services. If you'd like to test this behavior, to make sure it will work with your cluster:
+If you don't want a port to be temporarily forwarded, there is legacy behavior exposed with the flag `--use-proxy` or using environment `KUBECTL_COST_USE_PROXY` that will instead use the Kubernetes API server to proxy a request to Kubecost. This behavior has its own pitfalls, especially with security policies that would prevent the API server from communicating with services. If you'd like to test this behavior, to make sure it will work with your cluster:
 
 ``` sh
 kubectl proxy --port 8080
@@ -233,7 +234,7 @@ curl -G 'http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost
 
 > If you are running an old version of Kubecost, you may have to replace `tcp-model` with `model`
 
-If that `curl` succeeds, `KUBECTL_COST_USE_PROXY` set to true should work for you.
+If that `curl` succeeds, `--use-proxy` flag in CLI or setting up environment variable `KUBECTL_COST_USE_PROXY` should work for you.
 
 Otherwise:
 - There may be an underlying problem with your Kubecost install, try `kubectl port-forward`ing the `kubecost-cost-analyzer` service, port 9090, and querying [one of our APIs](https://github.com/kubecost/docs/blob/master/apis.md).

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -71,9 +71,7 @@ func addQueryBackendOptionsFlags(cmd *cobra.Command, options *query.QueryBackend
 	v := viper.New()
 	v.SetEnvPrefix(envPrefix)
 	v.AutomaticEnv()
-	options.UseProxy = v.GetBool("KUBECTL_COST_USE_PROXY")
 	bindAFlagToViperEnv(cmd, v, "use-proxy")
-	fmt.Printf("%v", options.UseProxy)
 }
 
 // addKubeOptionsFlags sets up the cobra command with the flags from

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/kubecost/kubectl-cost/pkg/query"
 	"github.com/kubecost/opencost/pkg/kubecost"
@@ -57,9 +58,13 @@ func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
 func addQueryBackendOptionsFlags(cmd *cobra.Command, options *query.QueryBackendOptions) {
 	cmd.Flags().StringVar(&options.ServiceName, "service-name", "kubecost-cost-analyzer", "The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart.")
 	cmd.Flags().IntVar(&options.ServicePort, "service-port", 9090, "The port of the service at which the APIs are running. If using OpenCost, you may want to set this to 9003.")
-	cmd.Flags().BoolVar(&options.UseProxy, "use-proxy", false, "Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.")
 	cmd.Flags().StringVarP(&options.KubecostNamespace, "kubecost-namespace", "N", "kubecost", "The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace.")
 	cmd.Flags().StringVar(&options.AllocationPath, "allocation-path", "/model/allocation", "URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute'")
+
+	//Check if environment variable KUBECTL_COST_USE_PROXY is set, it defaults to false
+	v := viper.New()
+	v.AutomaticEnv()
+	options.UseProxy = v.GetBool("KUBECTL_COST_USE_PROXY")
 }
 
 // addKubeOptionsFlags sets up the cobra command with the flags from


### PR DESCRIPTION
## What does this PR change?

Currently to use proxy Kubectl-cost uses --use-proxy flag, there's a proposal to assign it via environment variable KUBECTL_COST_USE_PROXY describe in the linked issue #107 , this is the code for this.

## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
There will be no support to use proxy via --use-proxy flag to the CLI of kubectl-cost, going forward it will be assigned through the flag KUBECTL_COST_USE_PROXY.


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/kubectl-cost/issues/107


## How was this PR tested?
Test case 1. Did not create an environment variable and debugged to see that the options.UseProxy is assigned to false
Test case 2. create an environment variable $KUBECTL_COST_USE_PROXY=true and debugged to see that the options.UseProxy is assigned to true
Test case 3. create an environment variable $KUBECTL_COST_USE_PROXY=false and debugged to see that the options.UseProxy is assigned to false

## Have you made an update to documentation?
Updated README.md, not sure if there's anywhere else to update the documentation
