### PR TITLE
Revert "adding environment variable KUBECTL_COST_USE_PROXY to set the --use-proxy behavior"

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The following flags modify the behavior of the subcommands:
 
 In order to provide a seamless experience for standard Kubernetes configurations, `kubectl-cost` temporarily forwards a port on your system to a Kubecost pod and uses that port to proxy a request. The port will only be bound to `localhost` and will only be open for the duration of the API request.
 
-If you don't want a port to be temporarily forwarded, there is legacy behavior exposed with the flag `--use-proxy` or using environment `KUBECTL_COST_USE_PROXY` that will instead use the Kubernetes API server to proxy a request to Kubecost. This behavior has its own pitfalls, especially with security policies that would prevent the API server from communicating with services. If you'd like to test this behavior, to make sure it will work with your cluster:
+If you don't want a port to be temporarily forwarded, there is legacy behavior exposed with the flag `--use-proxy` that will instead use the Kubernetes API server to proxy a request to Kubecost. This behavior has its own pitfalls, especially with security policies that would prevent the API server from communicating with services. If you'd like to test this behavior, to make sure it will work with your cluster:
 
 ``` sh
 kubectl proxy --port 8080
@@ -234,7 +234,7 @@ curl -G 'http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost
 
 > If you are running an old version of Kubecost, you may have to replace `tcp-model` with `model`
 
-If that `curl` succeeds, `--use-proxy` flag in CLI or setting up environment variable `KUBECTL_COST_USE_PROXY` should work for you.
+If that `curl` succeeds, `--use-proxy` should work for you.
 
 Otherwise:
 - There may be an underlying problem with your Kubecost install, try `kubectl port-forward`ing the `kubecost-cost-analyzer` service, port 9090, and querying [one of our APIs](https://github.com/kubecost/docs/blob/master/apis.md).

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/kubecost/kubectl-cost/pkg/query"
 	"github.com/kubecost/opencost/pkg/kubecost"
@@ -23,10 +21,6 @@ type CostOptions struct {
 	displayOptions
 	query.QueryBackendOptions
 }
-
-const (
-	envPrefix = "KUBECTL_COST"
-)
 
 // With the addition of commands which query the assets API,
 // some of these don't apply to all commands. However, as they
@@ -66,12 +60,6 @@ func addQueryBackendOptionsFlags(cmd *cobra.Command, options *query.QueryBackend
 	cmd.Flags().BoolVar(&options.UseProxy, "use-proxy", false, "Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.")
 	cmd.Flags().StringVarP(&options.KubecostNamespace, "kubecost-namespace", "N", "kubecost", "The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace.")
 	cmd.Flags().StringVar(&options.AllocationPath, "allocation-path", "/model/allocation", "URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute'")
-
-	//Check if environment variable KUBECTL_COST_USE_PROXY is set, it defaults to false
-	v := viper.New()
-	v.SetEnvPrefix(envPrefix)
-	v.AutomaticEnv()
-	bindAFlagToViperEnv(cmd, v, "use-proxy")
 }
 
 // addKubeOptionsFlags sets up the cobra command with the flags from
@@ -115,16 +103,4 @@ func (co *CostOptions) Validate() error {
 	}
 
 	return nil
-}
-
-// Binds the flag with viper environment variable and ensures the order of precendence
-// command line > environment variable > default value
-func bindAFlagToViperEnv(cmd *cobra.Command, v *viper.Viper, flag string) {
-	flagPtr := cmd.Flags().Lookup(flag)
-	envVarSuffix := strings.ToUpper(strings.ReplaceAll(flagPtr.Name, "-", "_"))
-	v.BindEnv(flagPtr.Name, fmt.Sprintf("%s_%s", envPrefix, envVarSuffix))
-	if !flagPtr.Changed && v.IsSet(flagPtr.Name) {
-		val := v.Get(flagPtr.Name)
-		cmd.Flags().Set(flagPtr.Name, fmt.Sprintf("%v", val))
-	}
 }


### PR DESCRIPTION
Reverts kubecost/kubectl-cost#122

#122 broke `--use-proxy`. Example output:
```
→ kubectl cost namespace --use-proxy 
Error: failed to query allocation API: failed to proxy get kubecost. err: the server is currently unable to handle the request (get services kubecost-cost-analyzer:⎂); data: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"no endpoints available for service \"kubecost-cost-analyzer:⎂\"","reason":"ServiceUnavailable","code":503}

Usage:
  cost namespace [flags]

Aliases:
  namespace, ns

Flags:
      --allocation-path string         URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute' (default "/model/allocation")
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default cache directory (default "/home/delta/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
  -h, --help                           help for namespace
      --historical                     show the total cost during the window instead of the projected monthly rate based on the data in the window
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -N, --kubecost-namespace string      The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace. (default "kubecost")
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --service-name string            The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart. (default "kubecost-cost-analyzer")
      --service-port int               The port of the service at which the APIs are running. If using OpenCost, you may want to set this to 9003. (default 9090)
  -A, --show-all-resources             Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency for namespace, deployment, controller, lable and pod OR --show-type --show-cpu --show-memory for node.
      --show-asset-type                show type of assets displayed.
      --show-cpu                       show data for CPU cost
      --show-efficiency                show efficiency of cost alongside CPU and memory cost (default true)
      --show-gpu                       show data for GPU cost
      --show-lb                        show load balancer cost data
      --show-memory                    show data for memory cost
      --show-network                   show data for network cost
      --show-pv                        show data for PV (physical volume) cost
      --show-shared                    show shared cost data
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --use-proxy                      Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.
      --user string                    The name of the kubeconfig user to use
      --window string                  The window of data to query. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here. (default "1d")

Global Flags:
      --log-level string   Set the log level from one of: 'trace', 'debug', 'info', 'warn', 'error'. (default "info")

```

Will re-merge the env var behavior when we get it working.