### PR TITLE
Fix use-proxy, bad port -> string conversion

### DIFF
--- a/pkg/query/allocation.go
+++ b/pkg/query/allocation.go
@@ -38,7 +38,7 @@ func QueryAllocation(p AllocationParameters) ([]map[string]kubecost.Allocation, 
 			return nil, fmt.Errorf("failed to create clientset for proxied query: %s", err)
 		}
 
-		bytes, err = clientset.CoreV1().Services(p.KubecostNamespace).ProxyGet("", p.ServiceName, string(p.ServicePort), p.AllocationPath, p.QueryParams).DoRaw(p.Ctx)
+		bytes, err = clientset.CoreV1().Services(p.KubecostNamespace).ProxyGet("", p.ServiceName, fmt.Sprint(p.ServicePort), p.AllocationPath, p.QueryParams).DoRaw(p.Ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
 		}


### PR DESCRIPTION
## What does this PR change?

Calling string() on an int results in a rune, not the expected string.
That caused an error like:

```
Error: failed to query allocation API: failed to proxy get kubecost. err: the server is currently unable to handle the request (get services kubecost-cost-analyzer:⎂); data: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"no endpoints available for service \"kubecost-cost-analyzer:⎂\"","reason":"ServiceUnavailable","code":503}
```

Note the port after `kubecost-cost-analyzer:`

After this commit, use-proxy works correctly.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fixes a regression in v0.2.9 where `--use-proxy` stopped working.

## How was this PR tested?

Manually. Observed use-proxy working after the change.