### PR TITLE
Check query error before accessing response

### DIFF
--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -242,14 +242,16 @@ func runTUI(ko *KubeOptions, do displayOptions, qo query.QueryBackendOptions) er
 				QueryBackendOptions: qo,
 			})
 
-			allocations = allocs[0]
-
 			if err != nil && strings.Contains(err.Error(), "context canceled") {
 				// do nothing, because the context got canceled to favor a more
 				// recent window request from the user
 			} else if err != nil {
 				log.Errorf("failed to query agg cost model: %s", err)
+			} else if len(allocations) == 0 {
+				log.Errorf("Allocation response was empty. Not updating the table.")
 			} else {
+				allocations = allocs[0]
+
 				lastUpdated = time.Now()
 				app.QueueUpdateDraw(func() {
 					redrawTable()


### PR DESCRIPTION
## What does this PR change?

We had a bug where failed queries in the TUI would return an error or
an empty response but we were trying to access the response before
checking the error or the response size. This shifts logic around to
handle the error first and then check if the response is empty before
trying to access it.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

The TUI logic has been updated to accurately handle a query error  case instead of panicking. See https://github.com/kubecost/kubectl-cost/issues/123 for an example.

## Links to Issues or ZD tickets this PR addresses or fixes

- Helps with https://github.com/kubecost/kubectl-cost/issues/123, but may not be a root-cause fix.

## How was this PR tested?

Locally after observing the panic as described in https://github.com/kubecost/kubectl-cost/issues/123. Now we get an error log instead of panicking. I am still working on fixing the underlying error.