### PR TITLE
Fix TUI allocation query always reporting empty

### DIFF
--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -231,7 +231,7 @@ func runTUI(ko *KubeOptions, do displayOptions, qo query.QueryBackendOptions) er
 			queryContext, queryCancel = context.WithCancel(context.Background())
 
 			// TODO: use flags for service name
-			allocs, err := query.QueryAllocation(query.AllocationParameters{
+			queriedAllocs, err := query.QueryAllocation(query.AllocationParameters{
 				RestConfig: ko.restConfig,
 				Ctx:        queryContext,
 				QueryParams: map[string]string{
@@ -247,10 +247,10 @@ func runTUI(ko *KubeOptions, do displayOptions, qo query.QueryBackendOptions) er
 				// recent window request from the user
 			} else if err != nil {
 				log.Errorf("failed to query agg cost model: %s", err)
-			} else if len(allocations) == 0 {
+			} else if len(queriedAllocs) == 0 {
 				log.Errorf("Allocation response was empty. Not updating the table.")
 			} else {
-				allocations = allocs[0]
+				allocations = queriedAllocs[0]
 
 				lastUpdated = time.Now()
 				app.QueueUpdateDraw(func() {


### PR DESCRIPTION
## What does this PR change?

Fixes the TUI always/almost always failing on startup with `ERR Allocation response was empty. Not updating the table.`

We were checking the wrong length, resulting in the TUI always failing
because the "allocations" is always initialized as empty. Updates the
naming of the query response variable for additional clarity in the
future.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fixes the TUI always/almost always failing on startup with `ERR Allocation response was empty. Not updating the table.`

## How was this PR tested?
Against a 1.96.0 Kubecost running in GKE. Observed failure before change and success after change.