### PR TITLE
Predict resource costs from spec: 'kubectl cost predict'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ with all cost components displayed.
 ``` sh
 kubectl cost namespace --show-all-resources
 ```
-Here is sample output:
+Example output:
 ```
 +-------------------+-----------+----------+----------+-------------+----------+----------+----------+-------------+--------------------+
 | NAMESPACE         | CPU       | CPU EFF. | MEMORY   | MEMORY EFF. | GPU      | PV       | NETWORK  | SHARED COST | MONTHLY RATE (ALL) |
@@ -79,6 +79,44 @@ Here is sample output:
 +-------------------+-----------+----------+----------+-------------+----------+----------+----------+-------------+--------------------+
 ```
 
+Predict the cost of a YAML spec based on its requests:
+``` sh
+read -r -d '' DEF << EndOfMessage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        resources:
+          requests:
+            cpu: "3"
+            memory: "2Gi"
+EndOfMessage
+echo "$DEF" | go run cmd/kubectl-cost/kubectl-cost.go predict -f -
+```
+Example output:
+```
++-----------------------------+-----+-----+------------+-----------+------------+
+| WORKLOAD                    | CPU | MEM | CPU/MO     | MEM/MO    | TOTAL/MO   |
++-----------------------------+-----+-----+------------+-----------+------------+
+| Deployment/nginx-deployment | 9   | 6Gi | 209.51 USD | 18.73 USD | 228.24 USD |
++-----------------------------+-----+-----+------------+-----------+------------+
+```
+
 Show how much each namespace cost over the past 5 days
 with additional CPU and memory cost and without efficiency.
 ``` sh
@@ -89,7 +127,6 @@ kubectl cost namespace \
   --show-memory \
   --show-efficiency=false
 ```
-
 
 Predict the cost of the Deployment defined in k8s-deployment.yaml.
 ``` sh

--- a/README.md
+++ b/README.md
@@ -168,32 +168,25 @@ Which yields an output with this format:
 ```
 
 #### Flags
-See `kubectl cost [subcommand] --help` for the full set of flags.
+See `kubectl cost [subcommand] --help` for the full set of flags. Each
+subcommand has its own set of flags for adjusting query behavior and output.
 
-The following flags modify the behavior of the subcommands:
+There are several flags that modify the behavior of queries to the backing
+Kubecost/OpenCost APIs:
 ```
-    --historical                  show the total cost during the window instead of the projected monthly rate based on the data in the window"
-    --show-asset-type             show type of assets displayed.
-    --show-cpu                    show data for CPU cost
-    --show-efficiency             show efficiency of cost alongside cost where available (default true)
-    --show-gpu                    show data for GPU cost
-    --show-lb                     show load balancer cost data
-    --show-memory                 show data for memory cost
-    --show-network                show data for network cost
-    --show-pv                     show data for PV (physical volume) cost
-    --show-shared                 show shared cost data
--A, --show-all-resources          Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency for namespace, deployment, controller, lable and pod OR --show-type --show-cpu --show-memory for node.
-    --window string               The window of data to query. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here. (default "1d")
--n, --namespace string            Limit results to only one namespace. Defaults to all namespaces.
-    --service-name string         The name of the kubecost cost analyzer service. Change if you're running a non-standard deployment, like the staging helm chart. (default "kubecost-cost-analyzer")
+    -r, --release-name string                 The name of the Helm release, used to template service names if they are unset. For example, if Kubecost is installed with 'helm install kubecost2 kubecost/cost-analyzer', then this should be set to 'kubecost2'. (default "kubecost")
+    --service-name string                 The name of the Kubecost cost analyzer service. By default, it is derived from the Helm release name and should not need to be overridden.
     --service-port int               The port of the service at which the APIs are running. If using OpenCost, you may want to set this to 9003. (default 9090)
-    --allocation-path string         URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute' (default "/model/allocation")
--N, --kubecost-namespace string   The namespace that kubecost is deployed in. Requests to the API will be directed to this namespace. (default "kubecost")
+    -N, --kubecost-namespace string           The namespace that Kubecost is deployed in. Requests to the API will be directed to this namespace. Defaults to the Helm release name.
+
     --use-proxy                   Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.
+
+    --allocation-path string         URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute' (default "/model/allocation")
+    --predict-resource-cost-path string   URL path at which Resource Cost Prediction queries can be served from the configured service. (default "/model/prediction/resourcecost")
 ```
 
 
-`kubectl cost` has to interact with the Kubernetes API server. It tries to use your kubeconfig. These flags are common to `kubectl` and allow you to customize this behavior.
+`kubectl cost` has to interact with the Kubernetes API server. It tries to use your existing kubeconfig. These flags are common to `kubectl` and allow you to customize this behavior:
 ``` sh
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ spec:
             cpu: "3"
             memory: "2Gi"
 EndOfMessage
-echo "$DEF" | go run cmd/kubectl-cost/kubectl-cost.go predict -f -
+echo "$DEF" | kubectl cost predict -f -
 ```
 Example output:
 ```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ kubectl cost namespace \
   --show-efficiency=false
 ```
 
+
+Predict the cost of the Deployment defined in k8s-deployment.yaml.
+``` sh
+kubectl cost predict -f 'k8s-deployment.yaml' \
+  --show-cost-per-resource-hr
+```
+
 Show the projected monthly rate for each controller
 based on the last 5 days of activity with PV (persistent
 volume) cost breakdown.

--- a/go.sum
+++ b/go.sum
@@ -411,7 +411,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kubecost/events v0.0.6/go.mod h1:i3DyCVatehxq6tAbvBrARuafjkX2DECPk9OWxiaRIhY=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kubecost/events v0.0.6/go.mod h1:i3DyCVatehxq6tAbvBrARuafjkX2DECPk9OWxiaRIhY=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -69,6 +69,7 @@ func addQueryBackendOptionsFlags(cmd *cobra.Command, options *query.QueryBackend
 	cmd.Flags().StringVar(&options.ServiceName, "service-name", "", "The name of the Kubecost cost analyzer service. By default, it is derived from the Helm release name and should not need to be overridden.")
 	cmd.Flags().BoolVar(&options.UseProxy, "use-proxy", false, "Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.")
 	cmd.Flags().StringVar(&options.AllocationPath, "allocation-path", "/model/allocation", "URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute'")
+	cmd.Flags().StringVar(&options.PredictResourceCostPath, "predict-resource-cost-path", "/model/prediction/resourcecost", "URL path at which Resource Cost Prediction queries can be served from the configured service.")
 
 	//Check if environment variable KUBECTL_COST_USE_PROXY is set, it defaults to false
 	v := viper.New()

--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -22,6 +22,7 @@ var (
     # based on the last 5 days of activity.
     %[1]s cost namespace --window 5d
 
+    # Predict the cost of the Deployment defined in k8s-deployment.yaml.
     %[1]s cost predict -f 'k8s-deployment.yaml' \
       --show-cost-per-resource-hr
 

--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -22,6 +22,8 @@ var (
     # based on the last 5 days of activity.
     %[1]s cost namespace --window 5d
 
+    %[1]s cost predict -f 'k8s-deployment.yaml'
+
     # Show how much each namespace cost over the past 5 days
     # with additional CPU and memory cost and without efficiency.
     %[1]s cost namespace \
@@ -177,6 +179,7 @@ helm install \
 	cmd.AddCommand(newCmdCostNode(streams))
 	cmd.AddCommand(newCmdTUI(streams))
 	cmd.AddCommand(newCmdVersion(streams, GitCommit, GitBranch, GitState, GitSummary, BuildDate))
+	cmd.AddCommand(newCmdPredict(streams))
 
 	return cmd
 }

--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -22,7 +22,8 @@ var (
     # based on the last 5 days of activity.
     %[1]s cost namespace --window 5d
 
-    %[1]s cost predict -f 'k8s-deployment.yaml'
+    %[1]s cost predict -f 'k8s-deployment.yaml' \
+      --show-cost-per-resource-hr
 
     # Show how much each namespace cost over the past 5 days
     # with additional CPU and memory cost and without efficiency.

--- a/pkg/cmd/output.go
+++ b/pkg/cmd/output.go
@@ -133,6 +133,10 @@ func makePredictionTable(rowData []predictRowData, currencyCode string, showCost
 		},
 	})
 
+	var summedMonthlyCPU float64
+	var summedMonthlyMem float64
+	var summedMonthlyTotal float64
+
 	for _, rowDatum := range rowData {
 		row := table.Row{}
 		row = append(row, fmt.Sprintf("%s/%s", rowDatum.workloadType, rowDatum.workloadName))
@@ -150,8 +154,30 @@ func makePredictionTable(rowData []predictRowData, currencyCode string, showCost
 		row = append(row, fmt.Sprintf("%.2f %s", rowDatum.prediction.MonthlyCostCPU, currencyCode))
 		row = append(row, fmt.Sprintf("%.2f %s", rowDatum.prediction.MonthlyCostMemory, currencyCode))
 		row = append(row, fmt.Sprintf("%.2f %s", rowDatum.prediction.MonthlyCostTotal, currencyCode))
+
+		summedMonthlyCPU += rowDatum.prediction.MonthlyCostCPU
+		summedMonthlyMem += rowDatum.prediction.MonthlyCostMemory
+		summedMonthlyTotal += rowDatum.prediction.MonthlyCostTotal
+
 		t.AppendRow(row)
 	}
+
+	// A summary footer is redundant if there is only one row
+	if len(rowData) > 1 {
+		footerRow := table.Row{}
+		blankRows := 3
+		if showCostPerResourceHr {
+			blankRows += 2
+		}
+		for i := 0; i < blankRows; i++ {
+			footerRow = append(footerRow, "")
+		}
+		footerRow = append(footerRow, fmt.Sprintf("%.2f %s", summedMonthlyCPU, currencyCode))
+		footerRow = append(footerRow, fmt.Sprintf("%.2f %s", summedMonthlyMem, currencyCode))
+		footerRow = append(footerRow, fmt.Sprintf("%.2f %s", summedMonthlyTotal, currencyCode))
+		t.AppendFooter(footerRow)
+	}
+
 	return t
 }
 

--- a/pkg/cmd/output.go
+++ b/pkg/cmd/output.go
@@ -110,7 +110,7 @@ func makePredictionTable(rowData []predictRowData, currencyCode string, showCost
 
 	// PredictColMoCoreHours,
 	// PredictColMoGibHours,
-	//
+
 	if showCostPerResourceHr {
 		headerRow = append(headerRow,
 			PredictColCostCoreHr,

--- a/pkg/cmd/output.go
+++ b/pkg/cmd/output.go
@@ -65,12 +65,6 @@ func makePredictionTable(rowData []predictRowData, currencyCode string, showCost
 			Name: PredictColReqMemory,
 		},
 	}
-	// table.ColumnConfig{
-	// 	Name: PredictColMoCoreHours,
-	// },
-	// table.ColumnConfig{
-	// 	Name: PredictColMoGibHours,
-	// },
 
 	if showCostPerResourceHr {
 		columnConfigs = append(columnConfigs, []table.ColumnConfig{
@@ -108,9 +102,6 @@ func makePredictionTable(rowData []predictRowData, currencyCode string, showCost
 		PredictColReqMemory,
 	}
 
-	// PredictColMoCoreHours,
-	// PredictColMoGibHours,
-
 	if showCostPerResourceHr {
 		headerRow = append(headerRow,
 			PredictColCostCoreHr,
@@ -142,9 +133,6 @@ func makePredictionTable(rowData []predictRowData, currencyCode string, showCost
 		row = append(row, fmt.Sprintf("%s/%s", rowDatum.workloadType, rowDatum.workloadName))
 		row = append(row, rowDatum.cpuStr)
 		row = append(row, rowDatum.memStr)
-
-		// row = append(row, prediction.MonthlyCoreHours)
-		// row = append(row, fmt.Sprintf("%.2f", prediction.MonthlyByteHours/1024/1024/1024))
 
 		if showCostPerResourceHr {
 			row = append(row, fmt.Sprintf("%.4f %s", rowDatum.prediction.DerivedCostPerCoreHour, currencyCode))

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -60,6 +60,7 @@ func newCmdPredict(
 				return err
 			}
 
+			predictO.Complete()
 			if err := predictO.Validate(); err != nil {
 				return err
 			}
@@ -85,7 +86,16 @@ func (predictO *PredictOptions) Validate() error {
 			return fmt.Errorf("file '%s' does not exist, not a valid option", predictO.filepath)
 		}
 	}
+
+	if err := predictO.QueryBackendOptions.Validate(); err != nil {
+		return fmt.Errorf("validating query options: %s", err)
+	}
+
 	return nil
+}
+
+func (predictO *PredictOptions) Complete() {
+	predictO.QueryBackendOptions.Complete()
 }
 
 func sumContainerResources(replicas int, spec v1.PodSpec) v1.ResourceList {

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -210,7 +210,8 @@ func runCostPredict(ko *KubeOptions, no *PredictOptions) error {
 		case *appsv1.DaemonSet:
 			name = typed.Name
 			kind = "DaemonSet"
-			return fmt.Errorf("DaemonSets are not supported because scheduling-dependent workloads are not yet supported")
+			log.Warnf("DaemonSets are not supported because scheduling-dependent workloads are not yet supported. Skipping %s/%s.", kind, name)
+			continue
 		default:
 			return fmt.Errorf("unsupported type: %T", obj)
 		}

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -31,8 +31,6 @@ import (
 type PredictOptions struct {
 	window string
 
-	// TODO: idle/no idle
-
 	clusterID string
 
 	// The file containing the workload definition to be predicted.

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -29,7 +29,7 @@ import (
 
 // PredictOptions contains options specific to prediction queries.
 type PredictOptions struct {
-	// TODO: window
+	window string
 
 	// TODO: idle/no idle
 
@@ -71,6 +71,7 @@ func newCmdPredict(
 	cmd.Flags().StringVarP(&predictO.filepath, "filepath", "f", "", "The file containing the workload definition whose cost should be predicted. E.g. a file might be 'test-deployment.yaml' containing an apps/v1 Deployment definition. '-' can also be passed, in which case workload definitions will be read from stdin.")
 	cmd.Flags().StringVarP(&predictO.clusterID, "cluster-id", "c", "", "The cluster ID (in Kubecost) of the presumed cluster which the workload will be deployed to. This is used to determine resource costs. Defaults to all clusters.")
 	cmd.Flags().BoolVar(&predictO.showCostPerResourceHr, "show-cost-per-resource-hr", false, "Show the calculated cost per resource-hr (e.g. $/byte-hour) used for the cost prediction.")
+	cmd.Flags().StringVar(&predictO.window, "window", "2d", "The window of cost data to base resource costs on. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 
 	addQueryBackendOptionsFlags(cmd, &predictO.QueryBackendOptions)
 	addKubeOptionsFlags(cmd, kubeO)
@@ -234,7 +235,7 @@ func runCostPredict(ko *KubeOptions, no *PredictOptions) error {
 			Ctx:                 context.Background(),
 			QueryBackendOptions: no.QueryBackendOptions,
 			QueryParams: map[string]string{
-				"window":          "2d", // TODO: flag
+				"window":          no.window,
 				"clusterID":       no.clusterID,
 				"requestedMemory": memStr,
 				"requestedCPU":    cpuStr,

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -74,6 +74,8 @@ func newCmdPredict(
 	addQueryBackendOptionsFlags(cmd, &predictO.QueryBackendOptions)
 	addKubeOptionsFlags(cmd, kubeO)
 
+	cmd.SilenceUsage = true
+
 	return cmd
 }
 

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/kubecost/kubectl-cost/pkg/query"
+
+	"github.com/kubecost/opencost/pkg/log"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	// yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// PredictOptions contains options specific to prediction queries.
+type PredictOptions struct {
+	// TODO: window
+
+	// TODO: idle/no idle
+
+	clusterID string
+
+	// The file containing the workload definition to be predicted.
+	filepath string
+
+	showCostPerResourceHr bool
+
+	query.QueryBackendOptions
+}
+
+func newCmdPredict(
+	streams genericclioptions.IOStreams,
+) *cobra.Command {
+	kubeO := NewKubeOptions(streams)
+	predictO := &PredictOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "predict",
+		Short: "Estimate the monthly cost of a workload based on tracked cluster resource costs.",
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := kubeO.Complete(c, args); err != nil {
+				return err
+			}
+			if err := kubeO.Validate(); err != nil {
+				return err
+			}
+
+			if err := predictO.Validate(); err != nil {
+				return err
+			}
+
+			return runCostPredict(kubeO, predictO)
+		},
+	}
+	cmd.Flags().StringVarP(&predictO.filepath, "filepath", "f", "", "The file containing the workload definition whose cost should be predicted. E.g. a file might be 'test-deployment.yaml' containing an apps/v1 Deployment definition.")
+	cmd.Flags().StringVarP(&predictO.clusterID, "cluster-id", "c", "", "The cluster ID (in Kubecost) of the presumed cluster which the workload will be deployed to. This is used to determine resource costs. Defaults to all clusters.")
+	cmd.Flags().BoolVar(&predictO.showCostPerResourceHr, "show-cost-per-resource-hr", false, "Show the calculated cost per resource-hr (e.g. $/byte-hour) used for the cost prediction.")
+
+	addQueryBackendOptionsFlags(cmd, &predictO.QueryBackendOptions)
+	addKubeOptionsFlags(cmd, kubeO)
+
+	return cmd
+}
+
+func (predictO *PredictOptions) Validate() error {
+	if _, err := os.Stat(predictO.filepath); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("file '%s' does not exist, not a valid option", predictO.filepath)
+	}
+	return nil
+}
+
+func sumContainerResources(replicas int, spec v1.PodSpec) v1.ResourceList {
+	podMemory := resource.NewQuantity(0, resource.BinarySI)
+	podCPU := resource.NewMilliQuantity(0, resource.DecimalSI)
+
+	for _, cntr := range spec.Containers {
+		requests := cntr.Resources.Requests
+		if ram, ok := requests[corev1.ResourceMemory]; ok {
+			podMemory.Add(ram)
+		}
+		if cpu, ok := requests[corev1.ResourceCPU]; ok {
+			podCPU.Add(cpu)
+		}
+	}
+
+	totalMemory := resource.NewQuantity(0, resource.BinarySI)
+	totalCPU := resource.NewMilliQuantity(0, resource.DecimalSI)
+	for i := 0; i < replicas; i++ {
+		totalMemory.Add(*podMemory)
+		totalCPU.Add(*podCPU)
+	}
+
+	return v1.ResourceList{
+		v1.ResourceCPU:    *totalCPU,
+		v1.ResourceMemory: *totalMemory,
+	}
+}
+
+func runCostPredict(ko *KubeOptions, no *PredictOptions) error {
+	b, err := ioutil.ReadFile(no.filepath)
+	if err != nil {
+		return fmt.Errorf("failed to read file '%s': %s", no.filepath, err)
+	}
+
+	// https://github.com/kubernetes/client-go/issues/193#issuecomment-343138889
+	// https://github.com/kubernetes/client-go/issues/193#issuecomment-377140518
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode(b, nil, nil)
+	if err != nil {
+		return fmt.Errorf("decoding from file: %s", err)
+	}
+
+	var totalResources v1.ResourceList
+	var name string
+	switch typed := obj.(type) {
+	case *appsv1.Deployment:
+		replicas := 1
+		if typed.Spec.Replicas == nil {
+			log.Warnf("replicas is nil, defaulting to 1")
+		} else {
+			replicas = int(*typed.Spec.Replicas)
+		}
+		name = typed.Name
+		totalResources = sumContainerResources(replicas, typed.Spec.Template.Spec)
+	case *appsv1.StatefulSet:
+		replicas := 1
+		if typed.Spec.Replicas == nil {
+			log.Warnf("replicas is nil, defaulting to 1")
+		} else {
+			replicas = int(*typed.Spec.Replicas)
+		}
+		name = typed.Name
+		totalResources = sumContainerResources(replicas, typed.Spec.Template.Spec)
+	case *v1.Pod:
+		name = typed.Name
+		totalResources = sumContainerResources(1, typed.Spec)
+	case *appsv1.DaemonSet:
+		name = typed.Name
+		return fmt.Errorf("DaemonSets are not supported because scheduling-dependent workloads are not yet supported")
+	default:
+		return fmt.Errorf("unsupported type: %T", obj)
+	}
+
+	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
+	})
+	if err != nil {
+		log.Debugf("failed to get currency code, displaying as empty string: %s", err)
+		currencyCode = ""
+	}
+
+	memStr := "0"
+	cpuStr := "0"
+	if mem, ok := totalResources[v1.ResourceMemory]; ok {
+		ptr := &mem
+		memStr = ptr.String()
+		log.Debugf("mem asapprox: %f", ptr.AsApproximateFloat64())
+	}
+	if cpu, ok := totalResources[v1.ResourceCPU]; ok {
+		ptr := &cpu
+		cpuStr = ptr.String()
+	}
+	log.Debugf("mem: '%s', cpu: '%s'", memStr, cpuStr)
+	prediction, err := query.QueryPredictResourceCost(query.ResourcePredictParameters{
+		RestConfig:          ko.restConfig,
+		Ctx:                 context.Background(),
+		QueryBackendOptions: no.QueryBackendOptions,
+		QueryParams: map[string]string{
+			"window":          "2d", // TODO: flag
+			"clusterID":       no.clusterID,
+			"requestedMemory": memStr,
+			"requestedCPU":    cpuStr,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("prediction query failed: %s", err)
+	}
+
+	writePredictionTable(ko.Out, name, currencyCode, cpuStr, memStr, prediction, no.showCostPerResourceHr)
+	return nil
+}

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/kubecost/kubectl-cost/pkg/query"
 
-	"github.com/kubecost/opencost/pkg/log"
+	"github.com/opencost/opencost/pkg/log"
 
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/query/options.go
+++ b/pkg/query/options.go
@@ -34,8 +34,12 @@ type QueryBackendOptions struct {
 	// The port at which the Service should be queried
 	ServicePort int
 
-	// The path at which can serve Allocation queries, e.g. "/model/allocation"
+	// A path which can serve Allocation queries, e.g. "/model/allocation"
 	AllocationPath string
+
+	// A path which can serve Resource Cost Prediction queries,
+	// e.g. "/prediction/resourcecost"
+	PredictResourceCostPath string
 
 	restConfig *rest.Config
 	pfQuerier  *PortForwardQuerier

--- a/pkg/query/prediction.go
+++ b/pkg/query/prediction.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/kubecost/opencost/pkg/log"
+	"github.com/opencost/opencost/pkg/log"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/pkg/query/prediction.go
+++ b/pkg/query/prediction.go
@@ -48,7 +48,7 @@ func QueryPredictResourceCost(p ResourcePredictParameters) (ResourceCostPredicti
 			return ResourceCostPredictionResponse{}, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
 		}
 	} else {
-		bytes, err = portForwardedQueryService(p.RestConfig, p.KubecostNamespace, p.ServiceName, p.PredictResourceCostPath, p.ServicePort, p.QueryParams, p.Ctx)
+		bytes, err = p.QueryBackendOptions.pfQuerier.queryGet(p.Ctx, p.PredictResourceCostPath, p.QueryParams)
 		if err != nil {
 			return ResourceCostPredictionResponse{}, fmt.Errorf("failed to port forward query: %s", err)
 		}

--- a/pkg/query/prediction.go
+++ b/pkg/query/prediction.go
@@ -1,0 +1,66 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubecost/opencost/pkg/log"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type ResourcePredictParameters struct {
+	RestConfig *rest.Config
+	Ctx        context.Context
+
+	QueryParams map[string]string
+
+	QueryBackendOptions
+}
+
+type ResourceCostPredictionResponse struct {
+	DerivedCostPerCoreHour float64 `json:"derivedCostPerCoreHour"`
+	DerivedCostPerByteHour float64 `json:"derivedCostPerByteHour"`
+
+	MonthlyCoreHours float64 `json:"monthlyCoreHours"`
+	MonthlyByteHours float64 `json:"monthlyByteHours"`
+
+	MonthlyCostMemory float64 `json:"monthlyCostMemory"`
+	MonthlyCostCPU    float64 `json:"monthlyCostCPU"`
+	MonthlyCostTotal  float64 `json:"monthlyCostTotal"`
+}
+
+func QueryPredictResourceCost(p ResourcePredictParameters) (ResourceCostPredictionResponse, error) {
+	var bytes []byte
+	var err error
+
+	// TODO: genericize query logic further?
+	if p.UseProxy {
+		clientset, err := kubernetes.NewForConfig(p.RestConfig)
+		if err != nil {
+			return ResourceCostPredictionResponse{}, fmt.Errorf("failed to create clientset for proxied query: %s", err)
+		}
+
+		bytes, err = clientset.CoreV1().Services(p.KubecostNamespace).ProxyGet("", p.ServiceName, fmt.Sprint(p.ServicePort), p.PredictResourceCostPath, p.QueryParams).DoRaw(p.Ctx)
+		if err != nil {
+			return ResourceCostPredictionResponse{}, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
+		}
+	} else {
+		bytes, err = portForwardedQueryService(p.RestConfig, p.KubecostNamespace, p.ServiceName, p.PredictResourceCostPath, p.ServicePort, p.QueryParams, p.Ctx)
+		if err != nil {
+			return ResourceCostPredictionResponse{}, fmt.Errorf("failed to port forward query: %s", err)
+		}
+	}
+
+	log.Debugf("Prediction response raw: %s", string(bytes))
+
+	var resp ResourceCostPredictionResponse
+	err = json.Unmarshal(bytes, &resp)
+	if err != nil {
+		return resp, fmt.Errorf("failed to unmarshal allocation response: %s", err)
+	}
+
+	return resp, nil
+}

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -22,6 +22,10 @@ binary=$1
 # based on the last 5 days of activity.
 $binary namespace --window 5d
 
+# https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+$binary predict -f "${SCRIPT_DIR}/multi.yaml"
+
 # Show how much each namespace cost over the past 5 days
 # with additional CPU and memory cost and without efficiency.
 $binary namespace \

--- a/test/multi.yaml
+++ b/test/multi.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        resources:
+          requests:
+            cpu: "3"
+            memory: "2Gi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-2
+  labels:
+    app: nginx
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        resources:
+          requests:
+            cpu: "2"
+            memory: "7Gi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    resources:
+      requests:
+        cpu: "350m"
+        memory: "200Mi"


### PR DESCRIPTION
## What does this PR change?

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Introduce the new `kubectl cost predict` command which predicts the cost of workloads based on resource requests. Try it with `kubectl cost predict -f "deployment.yaml"` or `kubectl get deployment -n kube-system -o yaml | kubectl cost predict -f -`. Requires a Kubecost version >= v1.100.


## Related
- Requires https://github.com/kubecost/kubecost-cost-model/pull/1132

## How was this PR tested?
Locally, targeting an as-yet-unreleased API.

## Have you made an update to documentation?
Yes, README updates for new and modified flags.