### PR TITLE
Add a flag to hide the idle row --hide-idle

### DIFF
--- a/pkg/cmd/aggregatedcommandbuilder.go
+++ b/pkg/cmd/aggregatedcommandbuilder.go
@@ -69,6 +69,7 @@ func runAggregatedAllocationCommand(ko *KubeOptions, co CostOptions, aggregation
 			"aggregate":        strings.Join(aggregation, ","),
 			"accumulate":       "true",
 			"filterNamespaces": co.filterNamespace,
+			"idle":             fmt.Sprintf("%t", !co.hideIdle),
 		},
 		QueryBackendOptions: co.QueryBackendOptions,
 	})

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -20,6 +20,7 @@ type CostOptions struct {
 
 	isHistorical bool
 	showAll      bool
+	hideIdle     bool
 
 	displayOptions
 	query.QueryBackendOptions
@@ -56,6 +57,7 @@ func addCostOptionsFlags(cmd *cobra.Command, options *CostOptions) {
 	cmd.Flags().BoolVar(&options.showLoadBalancerCost, "show-lb", false, "show load balancer cost data")
 	cmd.Flags().BoolVar(&options.showEfficiency, "show-efficiency", true, "show efficiency of cost alongside CPU and memory cost")
 	cmd.Flags().BoolVar(&options.showAssetType, "show-asset-type", false, "show type of assets displayed.")
+	cmd.Flags().BoolVar(&options.hideIdle, "hide-idle", false, "ignore __idle__ allocation data")
 	cmd.Flags().BoolVarP(&options.showAll, "show-all-resources", "A", false, "Equivalent to --show-cpu --show-memory --show-gpu --show-pv --show-network --show-efficiency for namespace, deployment, controller, lable and pod OR --show-type --show-cpu --show-memory for node.")
 
 	addQueryBackendOptionsFlags(cmd, &options.QueryBackendOptions)

--- a/pkg/cmd/label.go
+++ b/pkg/cmd/label.go
@@ -80,6 +80,7 @@ func runCostLabel(ko *KubeOptions, no *CostOptionsLabel) error {
 			"window":     no.window,
 			"aggregate":  strings.Join(aggregation, ","),
 			"accumulate": "true",
+			"idle":       fmt.Sprintf("%t", !no.hideIdle),
 		},
 		QueryBackendOptions: no.QueryBackendOptions,
 	})


### PR DESCRIPTION
## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- New flag `--hide-idle` to hide the `__idle__` Allocation row

## How was this PR tested?
Locally, targeting a live KC.