### PR TITLE
Improve multi-query perf with long-running forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,23 @@ The following flags modify the behavior of the subcommands:
 
 ## Implementation Quirks
 
-In order to provide a seamless experience for standard Kubernetes configurations, `kubectl-cost` temporarily forwards a port on your system to a Kubecost pod and uses that port to proxy a request. The port will only be bound to `localhost` and will only be open for the duration of the API request.
+In order to provide a seamless experience for standard Kubernetes
+configurations, `kubectl-cost` temporarily forwards a port on your system to a
+Kubecost pod and uses that port to proxy requests. The port will only be bound
+to `localhost` and will only be open for the duration of the `kubectl cost` run.
+Due to Linux default conventions, the port may appear as held for a little while
+after the run (see TCP's `TIME_WAIT`).
 
-If you don't want a port to be temporarily forwarded, there is legacy behavior exposed with the flag `--use-proxy` or using environment `KUBECTL_COST_USE_PROXY` that will instead use the Kubernetes API server to proxy a request to Kubecost. This behavior has its own pitfalls, especially with security policies that would prevent the API server from communicating with services. If you'd like to test this behavior, to make sure it will work with your cluster:
+If you don't want a port to be temporarily forwarded, there is legacy behavior
+exposed with the flag `--use-proxy` or using environment
+`KUBECTL_COST_USE_PROXY` that will instead use the Kubernetes API server to
+proxy requests to Kubecost. This behavior has its own pitfalls, especially with
+security policies that would prevent the API server from communicating with
+services. If you'd like to test this behavior, to make sure it will work with
+your cluster:
 
 ``` sh
 kubectl proxy --port 8080
-
 ```
 
 ``` sh

--- a/pkg/cmd/aggregatedcommandbuilder.go
+++ b/pkg/cmd/aggregatedcommandbuilder.go
@@ -29,8 +29,9 @@ func buildStandardAggregatedAllocationCommand(streams genericclioptions.IOStream
 				return err
 			}
 
-			costO.Complete()
-
+			if err := costO.Complete(kubeO.restConfig); err != nil {
+				return fmt.Errorf("completing options: %s", err)
+			}
 			if err := costO.Validate(); err != nil {
 				return err
 			}
@@ -53,7 +54,6 @@ func buildStandardAggregatedAllocationCommand(streams genericclioptions.IOStream
 func runAggregatedAllocationCommand(ko *KubeOptions, co CostOptions, aggregation []string) error {
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:          ko.restConfig,
 		Ctx:                 context.Background(),
 		QueryBackendOptions: co.QueryBackendOptions,
 	})
@@ -63,8 +63,7 @@ func runAggregatedAllocationCommand(ko *KubeOptions, co CostOptions, aggregation
 	}
 
 	allocations, err := query.QueryAllocation(query.AllocationParameters{
-		RestConfig: ko.restConfig,
-		Ctx:        context.Background(),
+		Ctx: context.Background(),
 		QueryParams: map[string]string{
 			"window":           co.window,
 			"aggregate":        strings.Join(aggregation, ","),

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/rest"
 
 	"github.com/kubecost/kubectl-cost/pkg/query"
 	"github.com/kubecost/opencost/pkg/kubecost"
@@ -96,7 +97,7 @@ func addKubeOptionsFlags(cmd *cobra.Command, ko *KubeOptions) {
 	// ko.configFlags.Namespace = &emptyStr
 }
 
-func (co *CostOptions) Complete() {
+func (co *CostOptions) Complete(restConfig *rest.Config) error {
 	if co.showAll {
 		co.showCPUCost = true
 		co.showMemoryCost = true
@@ -107,7 +108,10 @@ func (co *CostOptions) Complete() {
 		co.showLoadBalancerCost = true
 		co.showAssetType = true
 	}
-	co.QueryBackendOptions.Complete()
+	if err := co.QueryBackendOptions.Complete(restConfig); err != nil {
+		return fmt.Errorf("complete backend opts: %s", err)
+	}
+	return nil
 }
 
 func (co *CostOptions) Validate() error {

--- a/pkg/cmd/label.go
+++ b/pkg/cmd/label.go
@@ -37,8 +37,9 @@ func newCmdCostLabel(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			labelO.CostOptions.Complete()
-
+			if err := labelO.CostOptions.Complete(kubeO.restConfig); err != nil {
+				return fmt.Errorf("completing options: %s", err)
+			}
 			if err := labelO.CostOptions.Validate(); err != nil {
 				return err
 			}
@@ -65,7 +66,6 @@ func runCostLabel(ko *KubeOptions, no *CostOptionsLabel) error {
 	aggregation := []string{"cluster", fmt.Sprintf("label:%s", no.queryLabel)}
 
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:          ko.restConfig,
 		Ctx:                 context.Background(),
 		QueryBackendOptions: no.QueryBackendOptions,
 	})
@@ -75,8 +75,7 @@ func runCostLabel(ko *KubeOptions, no *CostOptionsLabel) error {
 	}
 
 	allocations, err := query.QueryAllocation(query.AllocationParameters{
-		RestConfig: ko.restConfig,
-		Ctx:        context.Background(),
+		Ctx: context.Background(),
 		QueryParams: map[string]string{
 			"window":     no.window,
 			"aggregate":  strings.Join(aggregation, ","),

--- a/pkg/cmd/node.go
+++ b/pkg/cmd/node.go
@@ -34,7 +34,9 @@ func newCmdCostNode(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			assetsO.CostOptions.Complete()
+			if err := assetsO.CostOptions.Complete(kubeO.restConfig); err != nil {
+				return fmt.Errorf("completing options: %s", err)
+			}
 
 			if err := assetsO.CostOptions.Validate(); err != nil {
 				return err
@@ -51,9 +53,7 @@ func newCmdCostNode(streams genericclioptions.IOStreams) *cobra.Command {
 }
 
 func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
-
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:          ko.restConfig,
 		Ctx:                 context.Background(),
 		QueryBackendOptions: no.QueryBackendOptions,
 	})
@@ -63,7 +63,6 @@ func runCostNode(ko *KubeOptions, no *CostOptionsNode) error {
 	}
 
 	assets, err := query.QueryAssets(query.AssetParameters{
-		RestConfig:          ko.restConfig,
 		Ctx:                 context.Background(),
 		Window:              no.window,
 		Accumulate:          "true",

--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -38,7 +38,9 @@ func newCmdTUI(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			tuiO.QueryBackendOptions.Complete()
+			if err := tuiO.QueryBackendOptions.Complete(kubeO.restConfig); err != nil {
+				return fmt.Errorf("completing query options: %s", err)
+			}
 			if err := tuiO.QueryBackendOptions.Validate(); err != nil {
 				return fmt.Errorf("validating query options: %s", err)
 			}
@@ -186,7 +188,6 @@ func runTUI(ko *KubeOptions, do displayOptions, qo query.QueryBackendOptions) er
 
 	// TODO: use flags for service name
 	currencyCode, err := query.QueryCurrencyCode(query.CurrencyCodeParameters{
-		RestConfig:          ko.restConfig,
 		Ctx:                 queryContext,
 		QueryBackendOptions: qo,
 	})
@@ -237,8 +238,7 @@ func runTUI(ko *KubeOptions, do displayOptions, qo query.QueryBackendOptions) er
 
 			// TODO: use flags for service name
 			queriedAllocs, err := query.QueryAllocation(query.AllocationParameters{
-				RestConfig: ko.restConfig,
-				Ctx:        queryContext,
+				Ctx: queryContext,
 				QueryParams: map[string]string{
 					"window":     windowOptions[windowIndex],
 					"aggregate":  strings.Join(aggregation, ","),

--- a/pkg/query/configapi.go
+++ b/pkg/query/configapi.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 type configsResponse struct {
@@ -16,8 +15,7 @@ type configsResponse struct {
 }
 
 type CurrencyCodeParameters struct {
-	RestConfig *rest.Config
-	Ctx        context.Context
+	Ctx context.Context
 
 	QueryBackendOptions
 }
@@ -27,7 +25,7 @@ func QueryCurrencyCode(p CurrencyCodeParameters) (string, error) {
 	var err error
 
 	if p.UseProxy {
-		clientset, err := kubernetes.NewForConfig(p.RestConfig)
+		clientset, err := kubernetes.NewForConfig(p.restConfig)
 		if err != nil {
 			return "", fmt.Errorf("failed to create clientset: %s", err)
 		}
@@ -38,7 +36,7 @@ func QueryCurrencyCode(p CurrencyCodeParameters) (string, error) {
 			return "", fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
 		}
 	} else {
-		bytes, err = portForwardedQueryService(p.RestConfig, p.KubecostNamespace, p.ServiceName, "model/getConfigs", p.ServicePort, nil, p.Ctx)
+		bytes, err = p.QueryBackendOptions.pfQuerier.queryGet(p.Ctx, "model/getConfigs", nil)
 		if err != nil {
 			return "", fmt.Errorf("failed to forward get kubecost: %s", err)
 		}

--- a/pkg/query/options.go
+++ b/pkg/query/options.go
@@ -1,9 +1,13 @@
 package query
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/kubecost/opencost/pkg/log"
+
+	"k8s.io/client-go/rest"
 )
 
 // QueryBackendOptions holds common options for managing the query backend used
@@ -32,9 +36,12 @@ type QueryBackendOptions struct {
 
 	// The path at which can serve Allocation queries, e.g. "/model/allocation"
 	AllocationPath string
+
+	restConfig *rest.Config
+	pfQuerier  *PortForwardQuerier
 }
 
-func (o *QueryBackendOptions) Complete() {
+func (o *QueryBackendOptions) Complete(restConfig *rest.Config) error {
 	if o.ServiceName == "" {
 		o.ServiceName = fmt.Sprintf("%s-cost-analyzer", o.HelmReleaseName)
 		log.Debugf("ServiceName set to: %s", o.ServiceName)
@@ -43,6 +50,17 @@ func (o *QueryBackendOptions) Complete() {
 		o.KubecostNamespace = o.HelmReleaseName
 		log.Debugf("KubecostNamespace set to: %s", o.KubecostNamespace)
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if !o.UseProxy {
+		pfQ, err := CreatePortForwardForService(restConfig, o.KubecostNamespace, o.ServiceName, o.ServicePort, ctx)
+		if err != nil {
+			return fmt.Errorf("port-forwarding requested service '%s' (port %d) in namespace '%s': %s", o.ServiceName, o.ServicePort, o.KubecostNamespace, err)
+		}
+		o.pfQuerier = pfQ
+	}
+	return nil
 }
 
 func (o *QueryBackendOptions) Validate() error {

--- a/pkg/query/portforward.go
+++ b/pkg/query/portforward.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,35 +21,12 @@ import (
 	"github.com/kubecost/opencost/pkg/log"
 )
 
-// reference: https://stackoverflow.com/questions/41545123/how-to-get-pods-under-the-service-with-client-go-the-client-library-of-kubernete
-func getServicePods(restConfig *rest.Config, namespace, serviceName string, ctx context.Context) (*corev1.PodList, error) {
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make clientset: %s", err)
-	}
-
-	svc, err := clientset.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get service %s in namespace %s: %s", serviceName, namespace, err)
-	}
-
-	labelSet := labels.Set(svc.Spec.Selector)
-	labelSelector := labelSet.AsSelector().String()
-
-	pods, err := clientset.CoreV1().
-		Pods(namespace).
-		List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pods in namespace %s for label selector %s: %s", namespace, labelSelector, err)
-	}
-
-	return pods, nil
+type PortForwardQuerier struct {
+	baseQueryURL string
+	stopCh       chan struct{}
 }
 
-// portForwardedQueryService finds the pods associated with the given namespace and service,
-// port forwards to them, and executes a GET request to the endpoint with the specified params.
-// It then stops the port forward.
-func portForwardedQueryService(restConfig *rest.Config, namespace, serviceName, endpoint string, servicePort int, params map[string]string, ctx context.Context) ([]byte, error) {
+func CreatePortForwardForService(restConfig *rest.Config, namespace, serviceName string, servicePort int, ctx context.Context) (*PortForwardQuerier, error) {
 	// First: find a pod to port forward to
 	pods, err := getServicePods(restConfig, namespace, serviceName, ctx)
 	if err != nil {
@@ -124,15 +102,12 @@ func portForwardedQueryService(restConfig *rest.Config, namespace, serviceName, 
 		}
 	}()
 
-	// Cleanup once we're done
-	defer close(stopCh)
-
 	// Fourth: wait until the port forward is ready, or we hit a timeout.
 	select {
 	case <-readyCh:
 		break
-	case <-time.After(1 * time.Minute):
-		return nil, fmt.Errorf("timed out (1 min) trying to port forward")
+	case <-time.After(15 * time.Second):
+		return nil, fmt.Errorf("timed out (15 sec) trying to port forward")
 	}
 
 	// Confirm that we've port forwarded and allows us to discover the local forwarded port.
@@ -145,12 +120,37 @@ func portForwardedQueryService(restConfig *rest.Config, namespace, serviceName, 
 		return nil, fmt.Errorf("unexpected error: no ports forwarded")
 	}
 
-	// Fifth: make the request to the forwarded port
-	// TODO: url path join properly
+	baseQueryURL := fmt.Sprintf("http://localhost:%d", ports[0].Local)
+	log.Debugf("Port-forward set up at: %s", baseQueryURL)
+
+	return &PortForwardQuerier{
+		baseQueryURL: baseQueryURL,
+		stopCh:       stopCh,
+	}, nil
+}
+
+// Stop ends the port forward session.
+func (pfq *PortForwardQuerier) Stop() {
+	pfq.baseQueryURL = ""
+	close(pfq.stopCh)
+}
+
+// queryGet relies on a live port-forward session to execute a GET request
+// against a forwarded service at the given path with the given params.
+func (pfq *PortForwardQuerier) queryGet(ctx context.Context, path string, params map[string]string) ([]byte, error) {
+	if pfq.baseQueryURL == "" {
+		return nil, fmt.Errorf("base port-forward URL must be non-empty")
+	}
+
+	fullPath, err := url.JoinPath(pfq.baseQueryURL, path)
+	if err != nil {
+		return nil, fmt.Errorf("joining paths (%s, %s): %s", pfq.baseQueryURL, path, err)
+	}
+
 	req, err := http.NewRequestWithContext(
 		ctx,
 		"GET",
-		fmt.Sprintf("http://localhost:%d/%s", ports[0].Local, endpoint),
+		fullPath,
 		nil,
 	)
 	if err != nil {
@@ -165,16 +165,41 @@ func portForwardedQueryService(restConfig *rest.Config, namespace, serviceName, 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to GET %s: %s", endpoint, err)
+		return nil, fmt.Errorf("failed to GET %s: %s", fullPath, err)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %s response body: %s", endpoint, err)
+		return nil, fmt.Errorf("failed to read %s response body: %s", fullPath, err)
 	}
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("received non-200 status code %d and data: %s", resp.StatusCode, body)
 	}
 
 	return body, nil
+}
+
+// reference: https://stackoverflow.com/questions/41545123/how-to-get-pods-under-the-service-with-client-go-the-client-library-of-kubernete
+func getServicePods(restConfig *rest.Config, namespace, serviceName string, ctx context.Context) (*corev1.PodList, error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make clientset: %s", err)
+	}
+
+	svc, err := clientset.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %s in namespace %s: %s", serviceName, namespace, err)
+	}
+
+	labelSet := labels.Set(svc.Spec.Selector)
+	labelSelector := labelSet.AsSelector().String()
+
+	pods, err := clientset.CoreV1().
+		Pods(namespace).
+		List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pods in namespace %s for label selector %s: %s", namespace, labelSelector, err)
+	}
+
+	return pods, nil
 }


### PR DESCRIPTION
## What does this PR change?
Shaves about half a second off of a regular kubectl cost namespace query and provides big time savings for multi-workload predictions. These savings should be linear with # of predictions because this avoids re-forwarding for every workload prediction.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Improved performance for multiple port-forwarded queries by maintaining a single port-forward session rather than re-forwarding for each query.

## How was this PR tested?
Locally with `kubectl cost predict` and `kubectl cost namespace`, observing improved perf in both cases but particularly in `predict` due to its multi-query nature.

Also checked to make sure ports aren't being leaked after the run with `ss -peanut`. Saw ports sticking around for a little while. Learned about TCP `TIME_WAIT` via https://unix.stackexchange.com/questions/68311/why-does-it-take-up-to-several-minutes-to-clean-a-listening-tcp-port-after-a-pro. The port is indeed released after a brief time.

## Have you made an update to documentation?
Yes, the README update in this PR.
