### PR TITLE
Add support for basic GPU cost prediction, support altered prediction API schema

### DIFF
--- a/pkg/query/prediction.go
+++ b/pkg/query/prediction.go
@@ -21,14 +21,17 @@ type ResourcePredictParameters struct {
 }
 
 type ResourceCostPredictionResponse struct {
-	DerivedCostPerCoreHour float64 `json:"derivedCostPerCoreHour"`
-	DerivedCostPerByteHour float64 `json:"derivedCostPerByteHour"`
+	DerivedCostPerCPUCoreHour    float64 `json:"derivedCostPerCPUCoreHour"`
+	DerivedCostPerMemoryByteHour float64 `json:"derivedCostPerMemoryByteHour"`
+	DerivedCostPerGPUHour        float64 `json:"derivedCostPerGPUHour"`
 
-	MonthlyCoreHours float64 `json:"monthlyCoreHours"`
-	MonthlyByteHours float64 `json:"monthlyByteHours"`
+	MonthlyCPUCoreHours    float64 `json:"monthlyCPUCoreHours"`
+	MonthlyMemoryByteHours float64 `json:"monthlyMemoryByteHours"`
+	MonthlyGPUHours        float64 `json:"monthlyGPUHours"`
 
 	MonthlyCostMemory float64 `json:"monthlyCostMemory"`
 	MonthlyCostCPU    float64 `json:"monthlyCostCPU"`
+	MonthlyCostGPU    float64 `json:"monthlyCostGPU"`
 	MonthlyCostTotal  float64 `json:"monthlyCostTotal"`
 }
 

--- a/test/multi.yaml
+++ b/test/multi.yaml
@@ -60,3 +60,22 @@ spec:
       requests:
         cpu: "350m"
         memory: "200Mi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    resources:
+      requests:
+        cpu: "350m"
+        memory: "200Mi"
+      limits:
+        nvidia.com/gpu: 1
+        amd.com/gpu: 1
+        gpu.intel.com/i915: 1


### PR DESCRIPTION
## What does this PR change?

Adds support for GPU cost prediction for standard AMD, Intel, and NVIDIA GPU plugins.


## Does this PR rely on any other PRs?
- Builds on https://github.com/kubecost/kubectl-cost/pull/132
- Updates predict response schema from changes in https://github.com/kubecost/kubecost-cost-model/pull/1132


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Adds support in `kubectl cost predict` for GPU cost for standard AMD, Intel, and NVIDIA GPU plugins (`amd.com/gpu`, `gpu.intel.com/i915`, `nvidia.com/gpu`).

## How was this PR tested?

```
→ go run cmd/kubectl-cost/kubectl-cost.go predict -f ./test/multi.yaml --window '2h'
+-------------------------------+------+-------+-----+------------+------------+-------------+-------------+
| WORKLOAD                      | CPU  | MEM   | GPU | CPU/MO     | MEM/MO     | GPU/MO      | TOTAL/MO    |
+-------------------------------+------+-------+-----+------------+------------+-------------+-------------+
| Deployment/nginx-deployment   | 9    | 6Gi   | 0   | 209.58 USD |  18.73 USD |    0.00 USD |  228.31 USD |
| Deployment/nginx-deployment-2 | 10   | 35Gi  | 0   | 232.87 USD | 109.23 USD |    0.00 USD |  342.10 USD |
| Pod/nginx-pod                 | 350m | 200Mi | 0   |   8.15 USD |   0.61 USD |    0.00 USD |    8.76 USD |
| Pod/nginx-pod                 | 350m | 200Mi | 3   |   8.15 USD |   0.61 USD | 2080.50 USD | 2089.26 USD |
+-------------------------------+------+-------+-----+------------+------------+-------------+-------------+
|                               |      |       |     | 458.75 USD | 129.18 USD | 2080.50 USD | 2668.42 USD |
+-------------------------------+------+-------+-----+------------+------------+-------------+-------------+
```

## Have you made an update to documentation?

N/A