### PR TITLE
Fix panic when --use-proxy is true

### DIFF
--- a/pkg/query/options.go
+++ b/pkg/query/options.go
@@ -63,6 +63,8 @@ func (o *QueryBackendOptions) Complete(restConfig *rest.Config) error {
 			return fmt.Errorf("port-forwarding requested service '%s' (port %d) in namespace '%s': %s", o.ServiceName, o.ServicePort, o.KubecostNamespace, err)
 		}
 		o.pfQuerier = pfQ
+	} else {
+		o.restConfig = restConfig
 	}
 	return nil
 }


### PR DESCRIPTION
## What does this PR change?
Refactor of query logic caused o.restConfig to always be nil. This commit fixes that by simply passing through the restConfig in the proxy query case.

Problem discovered by CI: https://github.com/kubecost/integration-ci-cd/actions/runs/4014159525/jobs/6906486306


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Fix panic when --use-proxy is true


## How was this PR tested?
Locally. Observed panic before change with `--use-proxy` and no panic after.