### PR TITLE
Add support for cost difference in "predict" using new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Example output:
 +-------------------+-----------+----------+----------+-------------+----------+----------+----------+-------------+--------------------+
 ```
 
-Predict the cost of a YAML spec based on its requests:
+Predict the cost impact of a YAML spec based on its requests:
 ``` sh
 read -r -d '' DEF << EndOfMessage
 apiVersion: apps/v1
@@ -110,11 +110,11 @@ echo "$DEF" | kubectl cost predict -f -
 ```
 Example output:
 ```
-+-----------------------------+-----+-----+------------+-----------+------------+
-| WORKLOAD                    | CPU | MEM | CPU/MO     | MEM/MO    | TOTAL/MO   |
-+-----------------------------+-----+-----+------------+-----------+------------+
-| Deployment/nginx-deployment | 9   | 6Gi | 209.51 USD | 18.73 USD | 228.24 USD |
-+-----------------------------+-----+-----+------------+-----------+------------+
++-------------------------------------+-----+-----+-----+------------+-----------+----------+-----------+-----------+------------+
+| WORKLOAD                            | CPU | MEM | GPU | CPU/MO     | MEM/MO    | GPU/MO   | Δ CPU/MO  | Δ MEM/MO  | TOTAL/MO   |
++-------------------------------------+-----+-----+-----+------------+-----------+----------+-----------+-----------+------------+
+| default/Deployment/nginx-deployment | 9   | 6Gi | 0   | 207.68 USD | 18.56 USD | 0.00 USD | 38.30 USD | 11.51 USD | 226.24 USD |
++-------------------------------------+-----+-----+-----+------------+-----------+----------+-----------+-----------+------------+
 ```
 
 Show how much each namespace cost over the past 5 days
@@ -227,6 +227,8 @@ Kubecost/OpenCost APIs:
 
     --allocation-path string         URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute' (default "/model/allocation")
     --predict-resource-cost-path string   URL path at which Resource Cost Prediction queries can be served from the configured service. (default "/model/prediction/resourcecost")
+    --predict-resource-cost-diff-path string   URL path at which Resource Cost Prediction diff queries can be served from the configured service. (default "/model/prediction/resourcecostdiff")
+    --no-diff                                  Set true to not attempt a cost difference with a matching in-cluster workload, if one can be found.
 ```
 
 

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -70,6 +70,7 @@ func addQueryBackendOptionsFlags(cmd *cobra.Command, options *query.QueryBackend
 	cmd.Flags().BoolVar(&options.UseProxy, "use-proxy", false, "Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.")
 	cmd.Flags().StringVar(&options.AllocationPath, "allocation-path", "/model/allocation", "URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute'")
 	cmd.Flags().StringVar(&options.PredictResourceCostPath, "predict-resource-cost-path", "/model/prediction/resourcecost", "URL path at which Resource Cost Prediction queries can be served from the configured service.")
+	cmd.Flags().StringVar(&options.PredictResourceCostDiffPath, "predict-resource-cost-diff-path", "/model/prediction/resourcecostdiff", "URL path at which Resource Cost Prediction diff queries can be served from the configured service.")
 
 	//Check if environment variable KUBECTL_COST_USE_PROXY is set, it defaults to false
 	v := viper.New()

--- a/pkg/cmd/cost.go
+++ b/pkg/cmd/cost.go
@@ -87,6 +87,11 @@ type KubeOptions struct {
 	restConfig *rest.Config
 	args       []string
 
+	// Namespace should be the currently-configured defaultNamespace of the client.
+	// This allows e.g. predict to fill in the defaultNamespace if one is not provided
+	// in the workload spec.
+	defaultNamespace string
+
 	genericclioptions.IOStreams
 }
 
@@ -194,7 +199,12 @@ func (o *KubeOptions) Complete(cmd *cobra.Command, args []string) error {
 
 	o.restConfig, err = o.configFlags.ToRESTConfig()
 	if err != nil {
-		return err
+		return fmt.Errorf("converting to REST config: %s", err)
+	}
+
+	o.defaultNamespace, _, err = o.configFlags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return fmt.Errorf("retrieving default namespace: %s", err)
 	}
 
 	return nil

--- a/pkg/query/options.go
+++ b/pkg/query/options.go
@@ -40,6 +40,9 @@ type QueryBackendOptions struct {
 	// A path which can serve Resource Cost Prediction queries,
 	// e.g. "/prediction/resourcecost"
 	PredictResourceCostPath string
+	// A path which can serve Resource Cost Prediction queries with diff,
+	// e.g. "/prediction/resourcecostdiff"
+	PredictResourceCostDiffPath string
 
 	restConfig *rest.Config
 	pfQuerier  *PortForwardQuerier

--- a/pkg/query/portforward.go
+++ b/pkg/query/portforward.go
@@ -162,6 +162,8 @@ func (pfq *PortForwardQuerier) queryGet(ctx context.Context, path string, params
 	}
 	req.URL.RawQuery = q.Encode()
 
+	log.Debugf("Executing GET to: %s", req.URL.String())
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/query/predictiondiff.go
+++ b/pkg/query/predictiondiff.go
@@ -1,0 +1,64 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/opencost/opencost/pkg/log"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type ResourceDiffPredictParameters struct {
+	RestConfig *rest.Config
+	Ctx        context.Context
+
+	QueryParams map[string]string
+
+	QueryBackendOptions
+}
+
+type ResourceCostDiffPredictionResponse struct {
+	MonthlyCostMemory float64 `json:"monthlyCostMemory"`
+	MonthlyCostCPU    float64 `json:"monthlyCostCPU"`
+	MonthlyCostGPU    float64 `json:"monthlyCostGPU"`
+	MonthlyCostTotal  float64 `json:"monthlyCostTotal"`
+
+	MonthlyCostMemoryDiff float64 `json:"monthlyCostMemoryDiff"`
+	MonthlyCostCPUDiff    float64 `json:"monthlyCostCPUDiff"`
+}
+
+func QueryPredictResourceCostDiff(p ResourceDiffPredictParameters) (ResourceCostDiffPredictionResponse, error) {
+	var bytes []byte
+	var err error
+
+	// TODO: genericize query logic further?
+	if p.UseProxy {
+		clientset, err := kubernetes.NewForConfig(p.RestConfig)
+		if err != nil {
+			return ResourceCostDiffPredictionResponse{}, fmt.Errorf("failed to create clientset for proxied query: %s", err)
+		}
+
+		bytes, err = clientset.CoreV1().Services(p.KubecostNamespace).ProxyGet("", p.ServiceName, fmt.Sprint(p.ServicePort), p.PredictResourceCostDiffPath, p.QueryParams).DoRaw(p.Ctx)
+		if err != nil {
+			return ResourceCostDiffPredictionResponse{}, fmt.Errorf("failed to proxy get kubecost. err: %s; data: %s", err, bytes)
+		}
+	} else {
+		bytes, err = p.QueryBackendOptions.pfQuerier.queryGet(p.Ctx, p.PredictResourceCostDiffPath, p.QueryParams)
+		if err != nil {
+			return ResourceCostDiffPredictionResponse{}, fmt.Errorf("failed to port forward query: %s", err)
+		}
+	}
+
+	log.Debugf("Prediction response raw: %s", string(bytes))
+
+	var resp ResourceCostDiffPredictionResponse
+	err = json.Unmarshal(bytes, &resp)
+	if err != nil {
+		return resp, fmt.Errorf("failed to unmarshal allocation response: %s", err)
+	}
+
+	return resp, nil
+}

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -25,6 +25,8 @@ $binary namespace --window 5d
 # https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 $binary predict -f "${SCRIPT_DIR}/multi.yaml"
+$binary predict --show-cost-per-resource-hr -f "${SCRIPT_DIR}/multi.yaml"
+$binary predict --no-diff --show-cost-per-resource-hr -f "${SCRIPT_DIR}/multi.yaml"
 
 # Show how much each namespace cost over the past 5 days
 # with additional CPU and memory cost and without efficiency.

--- a/test/multi.yaml
+++ b/test/multi.yaml
@@ -25,6 +25,31 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: kubecost-cost-analyzer
+  namespace: kubecost
+  labels:
+    app: kubecost-cost-analyzer
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kubecost-cost-analyzer
+  template:
+    metadata:
+      labels:
+        app: kubecost-cost-analyzer
+    spec:
+      containers:
+      - name: cost-model
+        image: nginx:1.14.2
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "3Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: nginx-deployment-2
   labels:
     app: nginx


### PR DESCRIPTION
## What does this PR change?
See release note. Diff behavior matches the current diff used by our new Admission Controller.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Added basic cost diffing support to `kubectl cost predict`. The default behavior will attempt to match workload specs with existing workloads tracked by Kubecost and will calculate a cost diff based on resource request. Disable with `--no-diff`.
- Added a namespace to the `kubectl cost predict` workload name output. If a namespace is not set on a given workload, it will be inherited from your Kubeconfig context.

## How was this PR tested?
- Targeted a dev cluster and the nightly cluster using the updated `test/multi.yaml` file. Observed full cost diffs on dev cluster (KC deployed in nonstandard namespace) and a true diff on the nightly cluster, as expected.

```
→ go run cmd/kubectl-cost/kubectl-cost.go predict -f ./test/multi.yaml --window '2h'
+--------------------------------------------+------+-------+-----+------------+------------+-------------+------------+------------+-------------+
| WORKLOAD                                   | CPU  | MEM   | GPU | CPU/MO     | MEM/MO     | GPU/MO      | Δ CPU/MO   | Δ MEM/MO   | TOTAL/MO    |
+--------------------------------------------+------+-------+-----+------------+------------+-------------+------------+------------+-------------+
| default/Deployment/nginx-deployment        | 9    | 6Gi   | 0   | 207.72 USD |  18.54 USD |    0.00 USD | 207.72 USD |  18.54 USD |  226.26 USD |
| kubecost/Deployment/kubecost-cost-analyzer | 15m  | 9Mi   | 0   |   0.35 USD |   0.03 USD |    0.00 USD |  -4.40 USD |  -0.37 USD |    0.37 USD |
| default/Deployment/nginx-deployment-2      | 10   | 35Gi  | 0   | 230.80 USD | 108.15 USD |    0.00 USD | 230.80 USD | 108.15 USD |  338.95 USD |
| default/Pod/nginx-pod                      | 350m | 200Mi | 0   |   8.08 USD |   0.60 USD |    0.00 USD |   8.08 USD |   0.60 USD |    8.68 USD |
| default/Pod/nginx-pod                      | 350m | 200Mi | 3   |   8.08 USD |   0.60 USD | 2080.50 USD |   8.08 USD |   0.60 USD | 2089.18 USD |
+--------------------------------------------+------+-------+-----+------------+------------+-------------+------------+------------+-------------+
|                                            |      |       |     | 455.02 USD | 127.92 USD | 2080.50 USD | 450.28 USD | 127.53 USD | 2663.45 USD |
+--------------------------------------------+------+-------+-----+------------+------------+-------------+------------+------------+-------------+
```

## Have you made an update to documentation?
Yes, README update in this PR.