### PR TITLE
Nick/split cost usage window

### DIFF
--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -23,7 +23,8 @@ import (
 
 // PredictOptions contains options specific to prediction queries.
 type PredictOptions struct {
-	window string
+	avgUsageWindow     string
+	resourceCostWindow string
 
 	clusterID string
 
@@ -65,7 +66,8 @@ func NewCmdPredict(
 	}
 	cmd.Flags().StringVarP(&predictO.filepath, "filepath", "f", "", "The file containing the workload definition whose cost should be predicted. E.g. a file might be 'test-deployment.yaml' containing an apps/v1 Deployment definition. '-' can also be passed, in which case workload definitions will be read from stdin.")
 	cmd.Flags().StringVarP(&predictO.clusterID, "cluster-id", "c", "", "The cluster ID (in Kubecost) of the presumed cluster which the workload will be deployed to. This is used to determine resource costs. Defaults to local cluster.")
-	cmd.Flags().StringVar(&predictO.window, "window", "2d", "The window of cost data to base resource costs on. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
+	cmd.Flags().StringVar(&predictO.avgUsageWindow, "window-usage", "2d", "The window of Kubecost data to calculate historical average usage from, if historical data exists. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
+	cmd.Flags().StringVar(&predictO.resourceCostWindow, "window-cost", "7d offset 48h", "The window of Kubecost data to base resource costs on. Defaults with an offset of 48h to incorporate reconciled data if reconciliation is set up. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 	cmd.Flags().BoolVar(&predictO.noUsage, "no-usage", false, "Set true ignore historical usage data (if any exists) when performing cost prediction.")
 
 	query.AddQueryBackendOptionsFlags(cmd, &predictO.QueryBackendOptions)
@@ -149,10 +151,11 @@ func runCostPredict(ko *utilities.KubeOptions, no *PredictOptions) error {
 		QueryBackendOptions: no.QueryBackendOptions,
 		SpecBytes:           b,
 		QueryParams: map[string]string{
-			"noUsage":          fmt.Sprint(no.noUsage),
-			"window":           no.window,
-			"clusterID":        no.clusterID,
-			"defaultNamespace": ko.DefaultNamespace,
+			"noUsage":            fmt.Sprint(no.noUsage),
+			"windowAvgUsage":     no.avgUsageWindow,
+			"windowResourceCost": no.resourceCostWindow,
+			"clusterID":          no.clusterID,
+			"defaultNamespace":   ko.DefaultNamespace,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## What does this PR change?
- Splits window flag into two separate flags. One for determining historical usage, and another for determining costs. 
  - This allows users to use reconciled cost data by passing a 48hr offset window.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/1290


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Added separate usage and cost window flags 


## Links to Issues or ZD tickets this PR addresses or fixes
- https://github.com/kubecost/kubecost-cost-model/issues/1250


## How was this PR tested?
Observed flags sending correct windows for both usage and cost

## Have you made an update to documentation?
No
