### PR TITLE
Add --show-total to show full cost alongside diff and --hide-diff to hide diff info

### DIFF
--- a/pkg/cmd/display/predict.go
+++ b/pkg/cmd/display/predict.go
@@ -39,7 +39,7 @@ func AddPredictDisplayOptionsFlags(cmd *cobra.Command, options *PredictDisplayOp
 
 func (o *PredictDisplayOptions) Validate() error {
 	if !o.ShowNew && o.HideDiff {
-		return fmt.Errorf("ShowAfter and HideDiff cannot be set such that no data will be shown")
+		return fmt.Errorf("ShowNew and HideDiff cannot be set such that no data will be shown")
 	}
 	return nil
 }
@@ -342,12 +342,12 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 	}
 
 	t.AppendFooter(table.Row{
-		"Total monthly cost change",
+		"Total monthly cost",
 		"",
 		"",
 		"",
 		"",
-		"",
+		totalCostNew,
 		totalCostImpact,
 	})
 

--- a/pkg/cmd/display/predict.go
+++ b/pkg/cmd/display/predict.go
@@ -19,11 +19,17 @@ const (
 	ColResourceUnit   = "resource unit"
 	ColMoDiffResource = "Δ qty"
 	ColMoDiffCost     = "Δ cost/mo"
+	ColMoResource     = "qty"
+	ColMoCost         = "cost/mo"
 	ColCostPerUnit    = "cost per unit"
 	ColPctChange      = "% change"
 )
 
-type PredictDisplayOptions struct{}
+type PredictDisplayOptions struct {
+	// ShowAfter determines if "After" cost info will be shown alongside the
+	// diff
+	ShowAfter bool
+}
 
 func AddPredictDisplayOptionsFlags(cmd *cobra.Command, options *PredictDisplayOptions) {
 }
@@ -42,9 +48,6 @@ func WritePredictionTable(out io.Writer, rowData []query.SpecCostDiff, currencyC
 // the decimal places.
 func fmtResourceFloat(x float64) string {
 	s := fmt.Sprintf("%.2f", x)
-	if x > 0 {
-		s = fmt.Sprintf("+%s", s)
-	}
 
 	// If formatted float ends in .000, remove
 	s = strings.TrimRight(s, "0")
@@ -80,9 +83,6 @@ func fmtResourceCostFloat(x float64) string {
 
 func fmtOverallCostFloat(x float64) string {
 	s := fmt.Sprintf("%.2f", x)
-	if x > 0 {
-		s = fmt.Sprintf("+%s", s)
-	}
 	return s
 }
 
@@ -114,11 +114,29 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			WidthMaxEnforcer: text.WrapSoft,
 		},
 		{
+			Name:   ColMoResource,
+			Hidden: !opts.ShowAfter,
+			Align:  text.AlignRight,
+			Transformer: func(val interface{}) string {
+				if f, ok := val.(float64); ok {
+					return fmtResourceFloat(f)
+				}
+				if s, ok := val.(string); ok {
+					return s
+				}
+				return "invalid value"
+			},
+		},
+		{
 			Name:  ColMoDiffResource,
 			Align: text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
-					return fmtResourceFloat(f)
+					s := fmtResourceFloat(f)
+					if f > 0 {
+						s = fmt.Sprintf("+%s", s)
+					}
+					return s
 				}
 				if s, ok := val.(string); ok {
 					return s
@@ -144,8 +162,9 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			},
 		},
 		{
-			Name:  ColMoDiffCost,
-			Align: text.AlignRight,
+			Name:   ColMoCost,
+			Hidden: !opts.ShowAfter,
+			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
 					return fmt.Sprintf("%s %s", fmtOverallCostFloat(f), currencyCode)
@@ -158,6 +177,36 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			TransformerFooter: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
 					return fmt.Sprintf("%s %s", fmtOverallCostFloat(f), currencyCode)
+				}
+				if s, ok := val.(string); ok {
+					return s
+				}
+				return "invalid value"
+			},
+		},
+		{
+			Name:  ColMoDiffCost,
+			Align: text.AlignRight,
+			Transformer: func(val interface{}) string {
+				if f, ok := val.(float64); ok {
+					s := fmt.Sprintf("%s %s", fmtOverallCostFloat(f), currencyCode)
+					if f > 0 {
+						s = fmt.Sprintf("+%s", s)
+					}
+					return s
+				}
+				if s, ok := val.(string); ok {
+					return s
+				}
+				return "invalid value"
+			},
+			TransformerFooter: func(val interface{}) string {
+				if f, ok := val.(float64); ok {
+					s := fmt.Sprintf("%s %s", fmtOverallCostFloat(f), currencyCode)
+					if f > 0 {
+						s = fmt.Sprintf("+%s", s)
+					}
+					return s
 				}
 				if s, ok := val.(string); ok {
 					return s
@@ -186,86 +235,107 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 
 	t.AppendHeader(table.Row{
 		ColObject,
+		ColMoResource,
 		ColMoDiffResource,
 		ColResourceUnit,
 		ColCostPerUnit,
+		ColMoCost,
 		ColMoDiffCost,
 		ColPctChange,
 	})
 
 	totalCostImpact := 0.0
+	totalCostNew := 0.0
 	for _, specData := range specDiffs {
 		totalCostImpact += specData.CostChange.TotalMonthlyRate
+		totalCostNew += specData.CostAfter.TotalMonthlyRate
 
 		workloadName := fmt.Sprintf("%s %s %s", specData.Namespace, specData.ControllerKind, specData.ControllerName)
 
 		// Don't show resource if there is no cost data before or after
 		if !(specData.CostBefore.CPUMonthlyRate == 0 && specData.CostAfter.CPUMonthlyRate == 0) {
-			cpuUnits := "CPU cores"
-			avgCPUInUnits := specData.CostChange.MonthlyCPUCoreHours / timeutil.HoursPerMonth
-			if avgCPUInUnits < 1 {
-				cpuUnits = "CPU millicores"
-				avgCPUInUnits = specData.CostChange.MonthlyCPUCoreHours / timeutil.HoursPerMonth * 1000
+			units := "CPU cores"
+			avgUnitsNew := specData.CostAfter.MonthlyCPUCoreHours / timeutil.HoursPerMonth
+			avgUnitsDiff := specData.CostChange.MonthlyCPUCoreHours / timeutil.HoursPerMonth
+			factor := 1.0
+			if avgUnitsNew < 1 {
+				units = "CPU millicores"
+				factor = 1000
 			}
-			costPerUnit := specData.CostChange.CPUMonthlyRate / avgCPUInUnits
-			cpuRow := table.Row{
+			avgUnitsDiff *= factor
+			avgUnitsNew *= factor
+			costPerUnit := specData.CostChange.CPUMonthlyRate / avgUnitsDiff
+			row := table.Row{
 				workloadName,
-				avgCPUInUnits,
-				cpuUnits,
+				avgUnitsNew,
+				avgUnitsDiff,
+				units,
 				costPerUnit,
+				specData.CostAfter.CPUMonthlyRate,
 				specData.CostChange.CPUMonthlyRate,
 			}
 			if specData.CostBefore.CPUMonthlyRate != 0 {
-				cpuRow = append(cpuRow, specData.CostChange.CPUMonthlyRate/specData.CostBefore.CPUMonthlyRate*100)
+				row = append(row, specData.CostChange.CPUMonthlyRate/specData.CostBefore.CPUMonthlyRate*100)
 			}
-			t.AppendRow(cpuRow)
+			t.AppendRow(row)
 		}
 
 		if !(specData.CostBefore.RAMMonthlyRate == 0 && specData.CostAfter.RAMMonthlyRate == 0) {
-
-			ramUnits := "RAM GiB"
-			ramUnitDivisor := 1024 * 1024 * 1024.0
-			avgRAMInUnits := specData.CostChange.MonthlyRAMByteHours / ramUnitDivisor / timeutil.HoursPerMonth
-			// If < 1 GiB, convert to MiB
-			if avgRAMInUnits < 1 {
-				ramUnits = "RAM MiB"
-				ramUnitDivisor = 1024 * 1024.0
-				avgRAMInUnits = specData.CostChange.MonthlyRAMByteHours / ramUnitDivisor / timeutil.HoursPerMonth
+			units := "RAM GiB"
+			avgUnitsNew := specData.CostAfter.MonthlyRAMByteHours / timeutil.HoursPerMonth
+			avgUnitsDiff := specData.CostChange.MonthlyRAMByteHours / timeutil.HoursPerMonth
+			factor := 1.0 / (1024 * 1024 * 1024)
+			if avgUnitsNew < 1 {
+				units = "RAM MiB"
+				factor = 1.0 / (1024 * 1024)
 			}
-			costPerUnit := specData.CostChange.RAMMonthlyRate / avgRAMInUnits
-			ramRow := table.Row{
+			avgUnitsDiff *= factor
+			avgUnitsNew *= factor
+			costPerUnit := specData.CostChange.RAMMonthlyRate / avgUnitsDiff
+			row := table.Row{
 				workloadName,
-				avgRAMInUnits,
-				ramUnits,
+				avgUnitsNew,
+				avgUnitsDiff,
+				units,
 				costPerUnit,
+				specData.CostAfter.RAMMonthlyRate,
 				specData.CostChange.RAMMonthlyRate,
 			}
 			if specData.CostBefore.RAMMonthlyRate != 0 {
-				ramRow = append(ramRow, specData.CostChange.RAMMonthlyRate/specData.CostBefore.RAMMonthlyRate*100)
+				row = append(row, specData.CostChange.RAMMonthlyRate/specData.CostBefore.RAMMonthlyRate*100)
 			}
-			t.AppendRow(ramRow)
+			t.AppendRow(row)
 		}
 
 		if !(specData.CostBefore.GPUMonthlyRate == 0 && specData.CostAfter.GPUMonthlyRate == 0) {
-			avgGPUs := specData.CostChange.MonthlyGPUHours / timeutil.HoursPerMonth
-			costPerGPU := specData.CostChange.GPUMonthlyRate / avgGPUs
-			gpuRow := table.Row{
+			units := "GPUs"
+			avgUnitsNew := specData.CostAfter.MonthlyGPUHours / timeutil.HoursPerMonth
+			avgUnitsDiff := specData.CostChange.MonthlyGPUHours / timeutil.HoursPerMonth
+			factor := 1.0
+			avgUnitsDiff *= factor
+			avgUnitsNew *= factor
+			costPerUnit := specData.CostChange.GPUMonthlyRate / avgUnitsDiff
+			row := table.Row{
 				workloadName,
-				avgGPUs,
-				"GPUs",
-				costPerGPU,
+				avgUnitsNew,
+				avgUnitsDiff,
+				units,
+				costPerUnit,
+				specData.CostAfter.GPUMonthlyRate,
 				specData.CostChange.GPUMonthlyRate,
 			}
 			if specData.CostBefore.GPUMonthlyRate != 0 {
-				gpuRow = append(gpuRow, specData.CostChange.GPUMonthlyRate/specData.CostBefore.GPUMonthlyRate*100)
+				row = append(row, specData.CostChange.GPUMonthlyRate/specData.CostBefore.GPUMonthlyRate*100)
 			}
-			t.AppendRow(gpuRow)
+			t.AppendRow(row)
 		}
 		t.AppendSeparator()
 	}
 
 	t.AppendFooter(table.Row{
 		"Total monthly cost change",
+		"",
+		"",
 		"",
 		"",
 		"",

--- a/pkg/cmd/display/predict.go
+++ b/pkg/cmd/display/predict.go
@@ -26,15 +26,21 @@ const (
 )
 
 type PredictDisplayOptions struct {
-	// ShowAfter determines if "After" cost info will be shown alongside the
+	// ShowNew determines if "After" cost info will be shown alongside the
 	// diff
-	ShowAfter bool
+	ShowNew bool
+
+	// HideDiff will disable diff information if true
+	HideDiff bool
 }
 
 func AddPredictDisplayOptionsFlags(cmd *cobra.Command, options *PredictDisplayOptions) {
 }
 
 func (o *PredictDisplayOptions) Validate() error {
+	if !o.ShowNew && o.HideDiff {
+		return fmt.Errorf("ShowAfter and HideDiff cannot be set such that no data will be shown")
+	}
 	return nil
 }
 
@@ -115,7 +121,7 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 		},
 		{
 			Name:   ColMoResource,
-			Hidden: !opts.ShowAfter,
+			Hidden: !opts.ShowNew,
 			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
@@ -128,8 +134,9 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			},
 		},
 		{
-			Name:  ColMoDiffResource,
-			Align: text.AlignRight,
+			Name:   ColMoDiffResource,
+			Hidden: opts.HideDiff,
+			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
 					s := fmtResourceFloat(f)
@@ -163,7 +170,7 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 		},
 		{
 			Name:   ColMoCost,
-			Hidden: !opts.ShowAfter,
+			Hidden: !opts.ShowNew,
 			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
@@ -185,8 +192,9 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			},
 		},
 		{
-			Name:  ColMoDiffCost,
-			Align: text.AlignRight,
+			Name:   ColMoDiffCost,
+			Hidden: opts.HideDiff,
+			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
 					s := fmt.Sprintf("%s %s", fmtOverallCostFloat(f), currencyCode)
@@ -215,8 +223,9 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			},
 		},
 		{
-			Name:  ColPctChange,
-			Align: text.AlignRight,
+			Name:   ColPctChange,
+			Hidden: opts.HideDiff,
+			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
 					prefix := ""

--- a/pkg/cmd/display/predict.go
+++ b/pkg/cmd/display/predict.go
@@ -39,7 +39,7 @@ func AddPredictDisplayOptionsFlags(cmd *cobra.Command, options *PredictDisplayOp
 
 func (o *PredictDisplayOptions) Validate() error {
 	if !o.ShowTotal && o.HideDiff {
-		return fmt.Errorf("ShowNew and HideDiff cannot be set such that no data will be shown")
+		return fmt.Errorf("ShowTotal and HideDiff cannot be set such that no data will be shown")
 	}
 	return nil
 }

--- a/pkg/cmd/display/predict.go
+++ b/pkg/cmd/display/predict.go
@@ -267,7 +267,7 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			avgUnitsNew := specData.CostAfter.MonthlyCPUCoreHours / timeutil.HoursPerMonth
 			avgUnitsDiff := specData.CostChange.MonthlyCPUCoreHours / timeutil.HoursPerMonth
 			factor := 1.0
-			if avgUnitsNew < 1 {
+			if avgUnitsNew*factor < 1 {
 				units = "CPU millicores"
 				factor = 1000
 			}
@@ -294,7 +294,7 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 			avgUnitsNew := specData.CostAfter.MonthlyRAMByteHours / timeutil.HoursPerMonth
 			avgUnitsDiff := specData.CostChange.MonthlyRAMByteHours / timeutil.HoursPerMonth
 			factor := 1.0 / (1024 * 1024 * 1024)
-			if avgUnitsNew < 1 {
+			if avgUnitsNew*factor < 1 {
 				units = "RAM MiB"
 				factor = 1.0 / (1024 * 1024)
 			}

--- a/pkg/cmd/display/predict.go
+++ b/pkg/cmd/display/predict.go
@@ -26,9 +26,9 @@ const (
 )
 
 type PredictDisplayOptions struct {
-	// ShowNew determines if "After" cost info will be shown alongside the
+	// ShowTotal determines if "After" cost info will be shown alongside the
 	// diff
-	ShowNew bool
+	ShowTotal bool
 
 	// HideDiff will disable diff information if true
 	HideDiff bool
@@ -38,7 +38,7 @@ func AddPredictDisplayOptionsFlags(cmd *cobra.Command, options *PredictDisplayOp
 }
 
 func (o *PredictDisplayOptions) Validate() error {
-	if !o.ShowNew && o.HideDiff {
+	if !o.ShowTotal && o.HideDiff {
 		return fmt.Errorf("ShowNew and HideDiff cannot be set such that no data will be shown")
 	}
 	return nil
@@ -121,7 +121,7 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 		},
 		{
 			Name:   ColMoResource,
-			Hidden: !opts.ShowNew,
+			Hidden: !opts.ShowTotal,
 			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {
@@ -170,7 +170,7 @@ func MakePredictionTable(specDiffs []query.SpecCostDiff, currencyCode string, op
 		},
 		{
 			Name:   ColMoCost,
-			Hidden: !opts.ShowNew,
+			Hidden: !opts.ShowTotal,
 			Align:  text.AlignRight,
 			Transformer: func(val interface{}) string {
 				if f, ok := val.(float64); ok {

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -69,7 +69,8 @@ func NewCmdPredict(
 	cmd.Flags().StringVar(&predictO.avgUsageWindow, "window-usage", "2d", "The window of Kubecost data to calculate historical average usage from, if historical data exists. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 	cmd.Flags().StringVar(&predictO.resourceCostWindow, "window-cost", "7d offset 48h", "The window of Kubecost data to base resource costs on. Defaults with an offset of 48h to incorporate reconciled data if reconciliation is set up. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 	cmd.Flags().BoolVar(&predictO.noUsage, "no-usage", false, "Set true ignore historical usage data (if any exists) when performing cost prediction.")
-	cmd.Flags().BoolVar(&predictO.ShowAfter, "show-new", false, "Show the total cost of the new spec alongside the diff.")
+	cmd.Flags().BoolVar(&predictO.ShowNew, "show-new", false, "Show the total cost of the new spec.")
+	cmd.Flags().BoolVar(&predictO.HideDiff, "hide-diff", false, "Hide the diff information.")
 
 	query.AddQueryBackendOptionsFlags(cmd, &predictO.QueryBackendOptions)
 	display.AddPredictDisplayOptionsFlags(cmd, &predictO.PredictDisplayOptions)

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -69,6 +69,7 @@ func NewCmdPredict(
 	cmd.Flags().StringVar(&predictO.avgUsageWindow, "window-usage", "2d", "The window of Kubecost data to calculate historical average usage from, if historical data exists. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 	cmd.Flags().StringVar(&predictO.resourceCostWindow, "window-cost", "7d offset 48h", "The window of Kubecost data to base resource costs on. Defaults with an offset of 48h to incorporate reconciled data if reconciliation is set up. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 	cmd.Flags().BoolVar(&predictO.noUsage, "no-usage", false, "Set true ignore historical usage data (if any exists) when performing cost prediction.")
+	cmd.Flags().BoolVar(&predictO.ShowAfter, "show-new", false, "Show the total cost of the new spec alongside the diff.")
 
 	query.AddQueryBackendOptionsFlags(cmd, &predictO.QueryBackendOptions)
 	display.AddPredictDisplayOptionsFlags(cmd, &predictO.PredictDisplayOptions)

--- a/pkg/cmd/predict.go
+++ b/pkg/cmd/predict.go
@@ -23,8 +23,7 @@ import (
 
 // PredictOptions contains options specific to prediction queries.
 type PredictOptions struct {
-	avgUsageWindow     string
-	resourceCostWindow string
+	window string
 
 	clusterID string
 
@@ -66,11 +65,10 @@ func NewCmdPredict(
 	}
 	cmd.Flags().StringVarP(&predictO.filepath, "filepath", "f", "", "The file containing the workload definition whose cost should be predicted. E.g. a file might be 'test-deployment.yaml' containing an apps/v1 Deployment definition. '-' can also be passed, in which case workload definitions will be read from stdin.")
 	cmd.Flags().StringVarP(&predictO.clusterID, "cluster-id", "c", "", "The cluster ID (in Kubecost) of the presumed cluster which the workload will be deployed to. This is used to determine resource costs. Defaults to local cluster.")
-	cmd.Flags().StringVar(&predictO.avgUsageWindow, "window-usage", "2d", "The window of Kubecost data to calculate historical average usage from, if historical data exists. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
-	cmd.Flags().StringVar(&predictO.resourceCostWindow, "window-cost", "7d offset 48h", "The window of Kubecost data to base resource costs on. Defaults with an offset of 48h to incorporate reconciled data if reconciliation is set up. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
+	cmd.Flags().StringVar(&predictO.window, "window", "2d", "The window of cost data to base resource costs on. See https://github.com/kubecost/docs/blob/master/allocation.md#querying for a detailed explanation of what can be passed here.")
 	cmd.Flags().BoolVar(&predictO.noUsage, "no-usage", false, "Set true ignore historical usage data (if any exists) when performing cost prediction.")
-	cmd.Flags().BoolVar(&predictO.ShowNew, "show-new", false, "Show the total cost of the new spec.")
-	cmd.Flags().BoolVar(&predictO.HideDiff, "hide-diff", false, "Hide the diff information.")
+	cmd.Flags().BoolVar(&predictO.ShowTotal, "show-total", false, "Show the total cost of the new spec(s). See --hide-diff for a similar option..")
+	cmd.Flags().BoolVar(&predictO.HideDiff, "hide-diff", false, "Hide the cost difference of applying the new spec(s). See --show-total for a similar option..")
 
 	query.AddQueryBackendOptionsFlags(cmd, &predictO.QueryBackendOptions)
 	display.AddPredictDisplayOptionsFlags(cmd, &predictO.PredictDisplayOptions)
@@ -153,11 +151,10 @@ func runCostPredict(ko *utilities.KubeOptions, no *PredictOptions) error {
 		QueryBackendOptions: no.QueryBackendOptions,
 		SpecBytes:           b,
 		QueryParams: map[string]string{
-			"noUsage":            fmt.Sprint(no.noUsage),
-			"windowAvgUsage":     no.avgUsageWindow,
-			"windowResourceCost": no.resourceCostWindow,
-			"clusterID":          no.clusterID,
-			"defaultNamespace":   ko.DefaultNamespace,
+			"noUsage":          fmt.Sprint(no.noUsage),
+			"window":           no.window,
+			"clusterID":        no.clusterID,
+			"defaultNamespace": ko.DefaultNamespace,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## What does this PR change?

See release note.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Added `--show-total` and `--hide-diff` flags to `kubectl cost predict`. "Total" cost is the expected monthly cost of each workload if the new spec were applied to your cluster. "Diff" cost (the default) is the expected monthly cost _change_ of applying each new spec to your cluster.


## Links to Issues or ZD tickets this PR addresses or fixes
https://kubecost.atlassian.net/browse/CORE-113

## How was this PR tested?
```
→ go run cmd/kubectl-cost/kubectl-cost.go predict -r michaelkc -f ./test/multi.yaml --show-total
 OBJECT                      QTY  Δ QTY  RESOURCE UNIT   COST PER UNIT      COST/MO     Δ COST/MO    % CHANGE 
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
 default deployment            9  +8.97  CPU cores           23.08 USD   207.68 USD   +206.99 USD  +29900.00% 
 nginx-deployment                                                                                             
                               6  +5.94  RAM GiB              3.09 USD    18.56 USD    +18.38 USD  +10140.00% 
                                                                                                              
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
 kubecost deployment          15    +15  CPU millicores      0.023 USD     0.35 USD     +0.35 USD             
 kubecost-cost-analyzer                                                                                       
                               9     +9  RAM MiB            0.0030 USD     0.03 USD     +0.03 USD             
                                                                                                              
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
 michaelkc deployment          1   -209  CPU millicores      0.023 USD     0.02 USD     -4.82 USD     -99.52% 
 michaelkc-cost-analyzer                                                                                      
                               1   -109  RAM MiB            0.0030 USD     0.00 USD     -0.33 USD     -99.09% 
                                                                                                              
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
 default deployment           10    +10  CPU cores           23.08 USD   230.76 USD   +230.76 USD             
 nginx-deployment-2                                                                                           
                              35    +35  RAM GiB              3.09 USD   108.26 USD   +108.26 USD             
                                                                                                              
                               5     +5  GPUs               693.50 USD  3467.50 USD  +3467.50 USD             
                                                                                                              
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
 default pod nginx-pod       350   +350  CPU millicores      0.023 USD     8.08 USD     +8.08 USD             
                             200   +200  RAM MiB            0.0030 USD     0.60 USD     +0.60 USD             
                            ──────────────────────────────────────────────────────────────────────────────────
                             350   +350  CPU millicores      0.023 USD     8.08 USD     +8.08 USD             
                             200   +200  RAM MiB            0.0030 USD     0.60 USD     +0.60 USD             
                               3     +3  GPUs               693.50 USD  2080.50 USD  +2080.50 USD             
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
 TOTAL MONTHLY COST                                                     6131.02 USD  +6124.97 USD             
```

```
→ go run cmd/kubectl-cost/kubectl-cost.go predict -r michaelkc -f ./test/multi.yaml --show-total --hide-diff
 OBJECT                      QTY  RESOURCE UNIT   COST PER UNIT      COST/MO 
─────────────────────────────────────────────────────────────────────────────
 default deployment            9  CPU cores           23.08 USD   207.68 USD 
 nginx-deployment                                                            
                               6  RAM GiB              3.09 USD    18.56 USD 
                                                                             
─────────────────────────────────────────────────────────────────────────────
 kubecost deployment          15  CPU millicores      0.023 USD     0.35 USD 
 kubecost-cost-analyzer                                                      
                               9  RAM MiB            0.0030 USD     0.03 USD 
                                                                             
─────────────────────────────────────────────────────────────────────────────
 michaelkc deployment          1  CPU millicores      0.023 USD     0.02 USD 
 michaelkc-cost-analyzer                                                     
                               1  RAM MiB            0.0030 USD     0.00 USD 
                                                                             
─────────────────────────────────────────────────────────────────────────────
 default deployment           10  CPU cores           23.08 USD   230.76 USD 
 nginx-deployment-2                                                          
                              35  RAM GiB              3.09 USD   108.26 USD 
                                                                             
                               5  GPUs               693.50 USD  3467.50 USD 
                                                                             
─────────────────────────────────────────────────────────────────────────────
 default pod nginx-pod       350  CPU millicores      0.023 USD     8.08 USD 
                             200  RAM MiB            0.0030 USD     0.60 USD 
                            ─────────────────────────────────────────────────
                             350  CPU millicores      0.023 USD     8.08 USD 
                             200  RAM MiB            0.0030 USD     0.60 USD 
                               3  GPUs               693.50 USD  2080.50 USD 
─────────────────────────────────────────────────────────────────────────────
 TOTAL MONTHLY COST                                              6131.02 USD 
```

```
→ go run cmd/kubectl-cost/kubectl-cost.go predict -r michaelkc -f ./test/multi.yaml --hide-diff           
Error: validate: validating display options: ShowTotal and HideDiff cannot be set such that no data will be shown
exit status 1
```

## Have you made an update to documentation?

Yes, the help text.