### PR TITLE
Fix kubectl-cost crashing on systems without glibc by disabling CGO for all builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+COMMONBUILDARGS := CGO_ENABLED=0
+
 .PHONY: darwin-amd64
 darwin-amd64:
-	cd cmd/kubectl-cost && GOOS=darwin GOARCH=amd64 govvv build -o kubectl-cost-darwin-amd64
+	cd cmd/kubectl-cost && ${COMMONBUILDARGS} GOOS=darwin GOARCH=amd64 govvv build -o kubectl-cost-darwin-amd64
 	tar --transform 's|.*kubectl-cost-darwin-amd64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-darwin-amd64.tar.gz \
 		cmd/kubectl-cost/kubectl-cost-darwin-amd64 \
@@ -8,7 +10,7 @@ darwin-amd64:
 
 .PHONY: darwin-arm64
 darwin-arm64:
-	cd cmd/kubectl-cost && GOOS=darwin GOARCH=arm64 govvv build -o kubectl-cost-darwin-arm64
+	cd cmd/kubectl-cost && ${COMMONBUILDARGS} GOOS=darwin GOARCH=arm64 govvv build -o kubectl-cost-darwin-arm64
 	tar --transform 's|.*kubectl-cost-darwin-arm64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-darwin-arm64.tar.gz \
 		cmd/kubectl-cost/kubectl-cost-darwin-arm64 \
@@ -16,7 +18,7 @@ darwin-arm64:
 
 .PHONY: linux-amd64
 linux-amd64:
-	cd cmd/kubectl-cost && GOOS=linux GOARCH=amd64 govvv build -o kubectl-cost-linux-amd64
+	cd cmd/kubectl-cost && ${COMMONBUILDARGS} GOOS=linux GOARCH=amd64 govvv build -o kubectl-cost-linux-amd64
 	tar --transform 's|.*kubectl-cost-linux-amd64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-linux-amd64.tar.gz \
 		cmd/kubectl-cost/kubectl-cost-linux-amd64 \
@@ -24,7 +26,7 @@ linux-amd64:
 
 .PHONY: windows-amd64
 windows-amd64:
-	cd cmd/kubectl-cost && GOOS=windows GOARCH=amd64 govvv build -o kubectl-cost-windows-amd64
+	cd cmd/kubectl-cost && ${COMMONBUILDARGS} GOOS=windows GOARCH=amd64 govvv build -o kubectl-cost-windows-amd64
 	tar --transform 's|.*kubectl-cost-windows-amd64|kubectl-cost|' \
 		-czf cmd/kubectl-cost/kubectl-cost-windows-amd64.tar.gz \
 		cmd/kubectl-cost/kubectl-cost-windows-amd64 \
@@ -39,7 +41,7 @@ release: darwin-amd64 darwin-arm64 linux-amd64 windows-amd64
 
 .PHONY: build
 build:
-	cd cmd/kubectl-cost && govvv build
+	cd cmd/kubectl-cost && ${COMMONBUILDARGS} govvv build
 
 .PHONY: install
 install: build


### PR DESCRIPTION
## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Fix kubectl-cost crashing on systems without glibc by disabling CGO for all builds


## Links to Issues or ZD tickets this PR addresses or fixes

- Closes https://github.com/kubecost/kubectl-cost/issues/147

## How was this PR tested?

Before
```
→ make build      
cd cmd/kubectl-cost && govvv build

→ ldd cmd/kubectl-cost/kubectl-cost 
	linux-vdso.so.1 (0x00007fff9ada9000)
	libresolv.so.2 => /usr/lib/libresolv.so.2 (0x00007fc0aa7a5000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007fc0aa5be000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fc0aa7cb000)
```

After
```
→ make build
cd cmd/kubectl-cost && CGO_ENABLED=0 govvv build

→ ldd cmd/kubectl-cost/kubectl-cost
	not a dynamic executable
```