### PR TITLE
Remove content type header for /prediction/speccost API calls

### DIFF
--- a/pkg/query/prediction_speccost.go
+++ b/pkg/query/prediction_speccost.go
@@ -54,9 +54,7 @@ func QuerySpecCost(p SpecCostParameters) (SpecCostResponse, error) {
 			p.Ctx,
 			p.PredictSpecCostPath,
 			p.QueryParams,
-			map[string]string{
-				"Content-Type": "application/yaml",
-			},
+			nil,
 			p.SpecBytes,
 		)
 		if err != nil {


### PR DESCRIPTION
## What does this PR change?
Remove content type header for /prediction/speccost calls

Backend no longer requires it, makes us flexible
for yaml and json



## Does this PR rely on any other PRs?

- Requires https://github.com/kubecost/kubecost-cost-model/pull/1916


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Added JSON manifest support to `kubectl cost predict`

## How was this PR tested?


## Have you made an update to documentation?

