### PR TITLE
Add `--opencost` flag to setup standard OpenCost configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Kubecost/OpenCost APIs:
 
     --predict-speccost-path string    URL path at which Prediction queries can be served from the configured service. (default "/model/prediction/speccost")
     --no-usage                        Set true ignore historical usage data (if any exists) when performing cost prediction.
-    --opencost                          Set true to configure Kubecost parameters according to the OpenCost default specification.
+    --opencost                        Set true to configure Kubecost parameters according to the OpenCost default specification. It is equivalent to providing the options '--service-port 9003 --service-name opencost --kubecost-namespace opencost --allocation-path /allocation/compute'
     --only-after                      Set true to only show the overall predicted cost of the workload.
     --only-diff                       Set true to only show the cost difference (cost "impact") instead of the overall cost plus diff. (default true)
 ```

--- a/README.md
+++ b/README.md
@@ -261,13 +261,13 @@ Kubecost/OpenCost APIs:
     --service-name string             The name of the Kubecost cost analyzer service. By default, it is derived from the Helm release name and should not need to be overridden.
     --service-port int                The port of the service at which the APIs are running. If using OpenCost, you may want to set this to 9003. (default 9090)
     -N, --kubecost-namespace string   The namespace that Kubecost is deployed in. Requests to the API will be directed to this namespace. Defaults to the Helm release name.
-
     --use-proxy                       Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.
 
     --allocation-path string          URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute' (default "/model/allocation")
 
     --predict-speccost-path string    URL path at which Prediction queries can be served from the configured service. (default "/model/prediction/speccost")
     --no-usage                        Set true ignore historical usage data (if any exists) when performing cost prediction.
+    --opencost                          Set true to configure Kubecost parameters according to the OpenCost default specification.
     --only-after                      Set true to only show the overall predicted cost of the workload.
     --only-diff                       Set true to only show the cost difference (cost "impact") instead of the overall cost plus diff. (default true)
 ```

--- a/pkg/query/options.go
+++ b/pkg/query/options.go
@@ -109,7 +109,7 @@ func AddQueryBackendOptionsFlags(cmd *cobra.Command, options *QueryBackendOption
 	cmd.Flags().BoolVar(&options.UseProxy, "use-proxy", false, "Instead of temporarily port-forwarding, proxy a request to Kubecost through the Kubernetes API server.")
 	cmd.Flags().StringVar(&options.AllocationPath, "allocation-path", "/model/allocation", "URL path at which Allocation queries can be served from the configured service. If using OpenCost, you may want to set this to '/allocation/compute'")
 	cmd.Flags().StringVar(&options.PredictSpecCostPath, "predict-speccost-path", "/model/prediction/speccost", "URL path at which Prediction queries can be served from the configured service.")
-	cmd.Flags().BoolVar(&options.OpenCost, "opencost", false, " Set true to configure Kubecost parameters according to the OpenCost default specification.")
+	cmd.Flags().BoolVar(&options.OpenCost, "opencost", false, " Set true to configure Kubecost parameters according to the OpenCost default specification. It is equivalent to providing the options '--service-port 9003 --service-name opencost --kubecost-namespace opencost --allocation-path /allocation/compute'.")
 
 	//Check if environment variable KUBECTL_COST_USE_PROXY is set, it defaults to false
 	v := viper.New()


### PR DESCRIPTION
## What does this PR change?

This Pull Request adds the `--opencost` flag to the cost command to setup standard OpenCost configuration. It is essentially an alias for the following flags:
`--service-port 9003 --service-name opencost --kubecost-namespace opencost --allocation-path /allocation/compute`

## Does this PR rely on any other PRs? 

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

The user will have the possibility to easily set OpenCost as the target service to the `kubectl cost` command by simply setting the `--opencost` instead of configuring the OpenCost default settings flag-by-flag.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/kubectl-cost/issues/156

## How was this PR tested?

This Pull Request was tested in an Oracle Kubernetes Engine (OKE)-based Kubernetes cluster configured with OpenCost and identical behaviour with providing the following flags was asserted:
`--service-port 9003 --service-name opencost --kubecost-namespace opencost --allocation-path /allocation/compute`

## Have you made an update to documentation?

An update was made in the README.md file.
