### PR TITLE
Add support for standard kubectl tracing

### DIFF
--- a/cmd/kubectl-cost/kubectl-cost.go
+++ b/cmd/kubectl-cost/kubectl-cost.go
@@ -4,10 +4,13 @@ import (
 	"os"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
 
 	"github.com/spf13/pflag"
 
 	"github.com/kubecost/kubectl-cost/pkg/cmd"
+
+	goflag "flag"
 )
 
 // The following are set by https://github.com/ahmetb/govvv during
@@ -27,6 +30,8 @@ type assetsQuery struct {
 func main() {
 	flags := pflag.NewFlagSet("kubectl-ns", pflag.ExitOnError)
 	pflag.CommandLine = flags
+	klog.InitFlags(nil)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
 	root := cmd.NewCmdCost(
 		genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},


### PR DESCRIPTION
## What does this PR change?
Add support for enabling K8S API client library tracing


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
I am having a problem with the portforwarding into the pod. Standard approach for debugging these kinds of issues is to pass `-v=9` argument to `kubectl` so I see the actual API traffic dumps in the logs. But `kubectl cost` doesn't support that argument, so there is no way to turn the K8S API client library tracing on. Hence, I have added support for those arguments.



## Links to Issues or ZD tickets this PR addresses or fixes
None



## How was this PR tested?
`kubectl cost namespace -v=9` shows K8S API traffic, for example:
```
I0914 09:10:41.594867   79299 loader.go:402] Config loaded from file:  /Users/skissane/.kube/example-kubeconfig
I0914 09:10:41.596519   79299 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0914 09:10:41.596537   79299 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0914 09:10:41.596552   79299 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0914 09:10:41.596562   79299 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0914 09:10:41.598641   79299 type.go:168] "Request Body" body=""
I0914 09:10:41.599672   79299 round_trippers.go:473] curl -v -XGET  -H "Accept: application/vnd.kubernetes.protobuf,application/json" -H "User-Agent: kubectl-cost/v0.0.0 (darwin/arm64) kubernetes/$Format" -H "Authorization: Bearer <masked>" 'https://kubernetes.dc.example.com/api/v1/namespaces/kubecost/services/kubecost-cost-analyzer'
I0914 09:10:41.604339   79299 round_trippers.go:502] HTTP Trace: DNS Lookup for kubernetes.dc.example.com resolved to [{10.234.156.178 }]
I0914 09:10:41.774487   79299 round_trippers.go:517] HTTP Trace: Dial to tcp:10.234.156.178:443 succeed
I0914 09:10:42.135729   79299 round_trippers.go:560] GET https://kubernetes.dc.example.com/api/v1/namespaces/kubecost/services/kubecost-cost-analyzer 401 Unauthorized in 535 milliseconds
I0914 09:10:42.136002   79299 round_trippers.go:577] HTTP Statistics: DNSLookup 2 ms Dial 170 ms TLSHandshake 188 ms ServerProcessing 170 ms Duration 535 ms
I0914 09:10:42.136047   79299 round_trippers.go:584] Response Headers:
I0914 09:10:42.136099   79299 round_trippers.go:587]     Audit-Id: 698c4097-ede4-48d2-961f-f199085a6d66
I0914 09:10:42.136131   79299 round_trippers.go:587]     Cache-Control: no-cache, private
I0914 09:10:42.136160   79299 round_trippers.go:587]     Content-Type: application/vnd.kubernetes.protobuf
I0914 09:10:42.136194   79299 round_trippers.go:587]     Date: Sat, 13 Sep 2025 23:10:42 GMT
I0914 09:10:42.136224   79299 round_trippers.go:587]     Content-Length: 72
I0914 09:10:42.136256   79299 round_trippers.go:587]     Strict-Transport-Security: max-age=31536000; includeSubDomains
I0914 09:10:42.136471   79299 type.go:168] "Response Body" body=<
	00000000  6b 38 73 00 0a 0c 0a 02  76 31 12 06 53 74 61 74  |k8s.....v1..Stat|
	00000010  75 73 12 30 0a 06 0a 00  12 00 1a 00 12 07 46 61  |us.0..........Fa|
	00000020  69 6c 75 72 65 1a 0c 55  6e 61 75 74 68 6f 72 69  |ilure..Unauthori|
	00000030  7a 65 64 22 0c 55 6e 61  75 74 68 6f 72 69 7a 65  |zed".Unauthorize|
	00000040  64 30 91 03 1a 00 22 00                           |d0....".|
 >
```

## Have you made an update to documentation?
No