### PR TITLE
Fix broken port forwarding on K8S 1.31+

### DIFF
--- a/pkg/query/portforward.go
+++ b/pkg/query/portforward.go
@@ -8,11 +8,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
@@ -25,6 +27,9 @@ type PortForwardQuerier struct {
 	baseQueryURL string
 	stopCh       chan struct{}
 }
+
+// Environment variable to revert to old method of using SPDY instead of WebSockets for K8S port-forwarding
+const KUBECOST_DISABLE_WEBSOCKETS = "KUBECOST_DISABLE_WEBSOCKETS"
 
 func CreatePortForwardForService(restConfig *rest.Config, namespace, serviceName string, servicePort int, ctx context.Context) (*PortForwardQuerier, error) {
 	// First: find a pod to port forward to
@@ -70,17 +75,30 @@ func CreatePortForwardForService(restConfig *rest.Config, namespace, serviceName
 	readyCh := make(chan struct{})
 	stopCh := make(chan struct{}, 1)
 
-	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create round tripper for rest config: %s", err)
-	}
+	mode := os.Getenv(KUBECOST_DISABLE_WEBSOCKETS)
+	log.Debugf("%s='%s'", KUBECOST_DISABLE_WEBSOCKETS, mode)
 
-	dialer := spdy.NewDialer(
-		upgrader,
-		&http.Client{Transport: transport},
-		http.MethodPost,
-		reqURL,
-	)
+	var dialer httpstream.Dialer
+	if mode != "true" {
+		log.Debugf("%s!=true: Use websocket mode for K8S 1.31+", KUBECOST_DISABLE_WEBSOCKETS)
+		dialer, err = portforward.NewSPDYOverWebsocketDialer(reqURL, restConfig)
+		if err != nil {
+			return nil, fmt.Errorf("websocket connection failure: %s", err)
+		}
+	} else {
+		log.Debugf("%s=true: Use SPDY mode for K8S pre-1.31", KUBECOST_DISABLE_WEBSOCKETS)
+
+		transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create round tripper for rest config: %s", err)
+		}
+		dialer = spdy.NewDialer(
+			upgrader,
+			&http.Client{Transport: transport},
+			http.MethodPost,
+			reqURL,
+		)
+	}
 
 	fw, err := portforward.New(
 		dialer,


### PR DESCRIPTION
## What does this PR change?
In K8S 1.31 and later, SPDY-based port forwarding is no longer supported – see [project announcement](https://kubernetes.io/blog/2024/08/20/websockets-transition/). But the code in `pkg/query/portforward.go` is written to use that. As a result, attempting to use `kubectl cost` will fail with this error:
```
panic: error upgrading connection: Upgrade request required

goroutine 22 [running]:
github.com/kubecost/kubectl-cost/pkg/query.CreatePortForwardForService.func1()
	/home/runner/work/kubectl-cost/kubectl-cost/pkg/query/portforward.go:101 +0x6c
created by github.com/kubecost/kubectl-cost/pkg/query.CreatePortForwardForService in goroutine 1
	/home/runner/work/kubectl-cost/kubectl-cost/pkg/query/portforward.go:98 +0x79c
```

I modified the code in `pkg/query/portforward.go` to use the new Websocket API instead.

I was worried that might break things for anyone trying to use this with an older K8S version which doesn't support WebSockets. So I added an environment variable `KUBECOST_DISABLE_WEBSOCKETS` to revert to the old code (if set to `true`) if it breaks it for anybody. Maybe it should be a command line option instead, but I was just trying to do the minimal thing necessary to fix my own problem.

## Does this PR rely on any other PRs?

- No. I found #217 useful in developing it, but it doesn't strictly depend on that

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

- Support was added for talking to newer Kubernetes versions (1.31 and higher).
- Environment variable `KUBECOST_DISABLE_WEBSOCKETS=true` added to revert to the old pre-1.31 communication mechanism, in case this change breaks using `kubectl cost` with older Kubernetes versions


## Links to Issues or ZD tickets this PR addresses or fixes

None


## How was this PR tested?

I have kubecost running under Kubernetes 1.33.

Before this PR, any attempt to use `kubectl cost` failed on it.

With this PR, it works.

## Have you made an update to documentation?

No